### PR TITLE
Upgrade Keycloak from 25 to 26.4

### DIFF
--- a/public/download/docker-compose.yml.template
+++ b/public/download/docker-compose.yml.template
@@ -127,7 +127,7 @@ services:
     depends_on:
       - edu-keycloak-db
     healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/9000"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
# Upgrade Keycloak 25 → 26.4

## 1. Stop the containers
```bash
cd /srv/docker/edulution-ui
docker compose down
````

## 2. Update `docker-compose.yml`

Change the Keycloak image and remove deprecated options:

```yaml
edu-keycloak:
  image: quay.io/keycloak/keycloak:26.4
  command:
    [
      'start',
      '--proxy-headers=xforwarded',
      '--http-enabled=true',
      '--hostname-strict=false'
    ]
```

**Removed deprecated options (no longer valid in 26.x):**

* `--proxy=edge`

**Removed environment variables:**

* `KC_PROXY`
* `KC_HOSTNAME_STRICT_HTTPS`

**Change the healthcheck:**

```
    healthcheck:
      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/9000"]
      interval: 5s
      timeout: 3s
      retries: 5
      start_period: 20s
```

## 3. Fix PostgreSQL collation mismatch

Start only the Keycloak DB:

```bash
docker compose up -d edu-keycloak-db
```

Refresh collation version:

```bash
docker exec -it edulution-keycloak-db psql -U keycloak -d keycloak -c "ALTER DATABASE keycloak REFRESH COLLATION VERSION;"
```

Reindex the database:

```bash
docker exec -it edulution-keycloak-db psql -U keycloak -d keycloak -c "REINDEX DATABASE keycloak;"
```

## 4. Start all containers

```bash
docker compose up -d
```

## 5. Verify Keycloak is running

```bash
docker logs -f edulution-keycloak
```
