### PR TITLE
feat(lmninstaller): edulution-fileproxy playbook (ES + deb + AD + traefik)

### DIFF
--- a/edulution-lmninstaller/README.md
+++ b/edulution-lmninstaller/README.md
@@ -87,6 +87,13 @@ curl http://10.0.0.1:8000/api/status
 | `GET` | `/api/playbook/{playbook}/requirements` | Check requirements |
 | `POST` | `/api/playbook/{playbook}/start` | Start playbook |
 
+### Available playbooks
+
+| Playbook | Purpose |
+|----------|---------|
+| `linuxmuster.yml` | Initial linuxmuster.net 7.3 install — runs on the DC |
+| `edulution-fileproxy.yml` | Installs edulution-fileproxy + Elasticsearch + AD service account + Traefik `/wiki` route. See the header of the playbook for `fp_*` variables. Typical `extra_vars`: `fp_indexer_password`, `fp_shares` (list of `{name, server?}`), and the three role-gating flags `fp_install_fileproxy` / `fp_configure_ad` / `fp_install_traefik_route`. |
+
 ### GET /api/playbook/{playbook}/requirements
 
 Checks system requirements for a playbook. Requirements are read from `playbooks/requirements/{playbook}`.

--- a/edulution-lmninstaller/README.md
+++ b/edulution-lmninstaller/README.md
@@ -92,7 +92,7 @@ curl http://10.0.0.1:8000/api/status
 | Playbook | Purpose |
 |----------|---------|
 | `linuxmuster.yml` | Initial linuxmuster.net 7.3 install — runs on the DC |
-| `edulution-fileproxy.yml` | Installs edulution-fileproxy + Elasticsearch + AD service account + Traefik `/wiki` route. See the header of the playbook for `fp_*` variables. Typical `extra_vars`: `fp_indexer_password`, `fp_shares` (list of `{name, server?}`), and the three role-gating flags `fp_install_fileproxy` / `fp_configure_ad` / `fp_install_traefik_route`. |
+| `edulution-fileproxy.yml` | Installs edulution-fileproxy + Elasticsearch + Traefik `/wiki` route. Uses the existing global-admin account for indexing (no AD objects created). See the header of the playbook for `fp_*` variables. Typical `extra_vars`: `fp_indexer_password` (global-admin password), `fp_shares` (list of `{name, server?}`), and the role-gating flags `fp_install_fileproxy` / `fp_install_traefik_route`. |
 
 ### GET /api/playbook/{playbook}/requirements
 

--- a/edulution-lmninstaller/README.md
+++ b/edulution-lmninstaller/README.md
@@ -92,7 +92,7 @@ curl http://10.0.0.1:8000/api/status
 | Playbook | Purpose |
 |----------|---------|
 | `linuxmuster.yml` | Initial linuxmuster.net 7.3 install — runs on the DC |
-| `edulution-fileproxy.yml` | Installs edulution-fileproxy + Elasticsearch + Traefik `/wiki` route. Uses the existing global-admin account for indexing (no AD objects created). See the header of the playbook for `fp_*` variables. Typical `extra_vars`: `fp_indexer_password` (global-admin password), `fp_shares` (list of `{name, server?}`), and the role-gating flags `fp_install_fileproxy` / `fp_install_traefik_route`. |
+| `edulution-fileproxy.yml` | Installs edulution-fileproxy + Elasticsearch + the Traefik route for the wiki API (`/wiki/search` and `/wiki/list` only — never the whole `/wiki` prefix, which would shadow the SPA's own wiki route). Uses the existing global-admin account for indexing (no AD objects created). See the header of the playbook for `fp_*` variables. Typical `extra_vars`: `fp_indexer_password` (global-admin password), `fp_shares` (list of `{name, server?}`), and the role-gating flags `fp_install_fileproxy` / `fp_install_traefik_route`. |
 
 ### GET /api/playbook/{playbook}/requirements
 

--- a/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
+++ b/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
@@ -1,0 +1,346 @@
+---
+# =============================================================================
+# EDULUTION-FILEPROXY INSTALLATION PLAYBOOK
+# =============================================================================
+#
+# Installiert edulution-fileproxy (SMB-proxy + Wiki-HTTP-API) + Elasticsearch
+# + legt den AD-Service-Account an + integriert die Traefik-Route für /wiki.
+#
+# Das Playbook ist in drei unabhängige Abschnitte aufgeteilt, die jeweils
+# per Variable aktiviert werden. Single-Host-Deployment = alle drei true;
+# verteilte Deployment = je Host das passende Flag.
+#
+#   fp_install_fileproxy        → ES + Paket + Config + Secret + Systemd
+#   fp_configure_ad             → samba-tool user/group/grants (nur auf dem DC)
+#   fp_install_traefik_route    → dynamic-config-File für Traefik
+#
+# Verwendung:
+#   ansible-playbook edulution-fileproxy.yml -e @vars/edulution-fileproxy_vars.yml
+#
+# Oder via API mit extra_vars:
+#   POST /api/playbook/edulution-fileproxy/start
+#   {
+#     "variables": {
+#       "extra_vars": {
+#         "fp_install_fileproxy": true,
+#         "fp_configure_ad": false,
+#         "fp_indexer_password": "...32-char random...",
+#         "fp_shares": [
+#           {"name": "default-school"},
+#           {"name": "agy", "server": "10.1.0.2"}
+#         ]
+#       }
+#     }
+#   }
+# =============================================================================
+
+- name: edulution-fileproxy Installation
+  hosts: localhost
+  connection: local
+  become: true
+  gather_facts: true
+
+  vars_files:
+    - vars/edulution-fileproxy_vars.yml
+
+  tasks:
+
+    # =========================================================================
+    # BASELINE SANITY — beide Abschnitte brauchen ein gesetztes Passwort
+    # =========================================================================
+
+    - name: Ensure fp_indexer_password is set
+      ansible.builtin.assert:
+        that:
+          - fp_indexer_password | length >= 12
+        fail_msg: |
+          fp_indexer_password must be provided (min 12 chars) via extra_vars.
+          Generate one with:  tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32
+      when: fp_install_fileproxy or fp_configure_ad
+
+    # =========================================================================
+    # ABSCHNITT 1 — AD SERVICE ACCOUNT (nur auf dem Samba-DC laufen lassen)
+    # =========================================================================
+    # Legt den Service-Account + die Gruppe + die share-`valid users`-Grants
+    # an. Idempotent: vorhandene Objekte werden nicht neu erstellt. Erweitert
+    # bestehende `valid users`-Strings additiv, damit andere Grants
+    # (administrator, @SCHOOLS, ...) erhalten bleiben.
+
+    - name: AD — create indexer service user
+      when: fp_configure_ad
+      block:
+
+        - name: Check if indexer service user exists
+          ansible.builtin.command: samba-tool user show {{ fp_indexer_user }}
+          register: fp_user_check
+          changed_when: false
+          failed_when: false
+
+        - name: Create indexer service user
+          ansible.builtin.command: >
+            samba-tool user create {{ fp_indexer_user }} '{{ fp_indexer_password }}'
+            --description="Fileproxy indexer service account"
+            --given-name="Edulution"
+            --surname="Indexer"
+          when: fp_user_check.rc != 0
+          no_log: true
+
+        - name: Ensure password never expires
+          ansible.builtin.command: samba-tool user setexpiry {{ fp_indexer_user }} --noexpiry
+          when: fp_user_check.rc != 0
+          changed_when: true
+
+        - name: Set NOT_DELEGATED flag (userAccountControl=1114624)
+          # NORMAL_ACCOUNT (512) + DONT_EXPIRE_PASSWORD (65536) + NOT_DELEGATED (1048576)
+          ansible.builtin.command: samba-tool user edit {{ fp_indexer_user }}
+          environment:
+            EDITOR: "sed -i 's/^userAccountControl:.*/userAccountControl: 1114624/'"
+          when: fp_user_check.rc != 0
+          changed_when: true
+
+        - name: Rotate password on existing user (when already present)
+          # Idempotent re-run: ensure the secret file and AD stay in sync.
+          ansible.builtin.command: >
+            samba-tool user setpassword {{ fp_indexer_user }}
+            --newpassword='{{ fp_indexer_password }}'
+          when: fp_user_check.rc == 0
+          no_log: true
+          changed_when: true
+
+    - name: AD — create indexer readers group + memberships
+      when: fp_configure_ad
+      block:
+
+        - name: Check if indexer readers group exists
+          ansible.builtin.command: samba-tool group show {{ fp_indexer_readers_group }}
+          register: fp_group_check
+          changed_when: false
+          failed_when: false
+
+        - name: Create indexer readers group
+          ansible.builtin.command: >
+            samba-tool group add {{ fp_indexer_readers_group }}
+            --description="Read-only scope for the fileproxy indexer"
+          when: fp_group_check.rc != 0
+          changed_when: true
+
+        - name: Add service user to indexer readers group (idempotent)
+          ansible.builtin.shell: |
+            samba-tool group addmembers {{ fp_indexer_readers_group }} {{ fp_indexer_user }} 2>&1 | \
+              grep -v 'already a member' || true
+          changed_when: true
+          # On some samba-tool versions the "already a member" status code
+          # is non-zero; grep -v + || true filters the benign case.
+
+        - name: Add service user to global-admins (filesystem bypass for linuxmuster)
+          # linuxmuster breaks NTFS inheritance at every folder level under
+          # per-user homes, so per-folder ACL grants cannot be practically
+          # recursed. global-admins already has OI|CI/FULL on every folder
+          # the linuxmuster setup scripts create — joining the svc account
+          # to this group bypasses the inheritance problem without leaking
+          # interactive credentials. See docs/OPERATOR_RUNBOOK.md
+          # § Indexer service account Step 3b in the fileproxy repo.
+          ansible.builtin.shell: |
+            samba-tool group addmembers global-admins {{ fp_indexer_user }} 2>&1 | \
+              grep -v 'already a member' || true
+          changed_when: true
+
+    - name: AD — share-level valid users (per share hosted locally)
+      when: fp_configure_ad and fp_shares | length > 0
+      block:
+
+        - name: Check each share's current valid users
+          ansible.builtin.shell: |
+            net conf getparm "{{ item.name }}" "valid users" 2>/dev/null || echo ''
+          loop: '{{ fp_shares }}'
+          register: fp_share_valid_users
+          changed_when: false
+          # A share not in the local registry (DFS proxy on a different
+          # fileserver) silently returns empty; the next step then skips it.
+
+        - name: Extend valid users with indexer-readers group
+          ansible.builtin.shell: |
+            set -e
+            current='{{ item.stdout | trim }}'
+            # Skip shares that aren't local to this DC (DFS proxies register
+            # with different net conf metadata; getparm returns empty for
+            # them).
+            net conf getparm "{{ item.item.name }}" "path" >/dev/null 2>&1 || exit 0
+            if echo "$current" | grep -q '{{ fp_indexer_readers_group }}'; then
+              echo "already granted"
+              exit 0
+            fi
+            if [ -z "$current" ]; then
+              net conf setparm "{{ item.item.name }}" "valid users" "@{{ fp_smb_domain }}\\{{ fp_indexer_readers_group }}"
+            else
+              net conf setparm "{{ item.item.name }}" "valid users" "$current,@{{ fp_smb_domain }}\\{{ fp_indexer_readers_group }}"
+            fi
+          loop: '{{ fp_share_valid_users.results }}'
+          loop_control:
+            label: '{{ item.item.name }}'
+          when: item.item.server is not defined or item.item.server == fp_smb_default_server
+          changed_when: true
+
+    # =========================================================================
+    # ABSCHNITT 2 — ELASTICSEARCH + FILEPROXY auf dem Fileproxy-Host
+    # =========================================================================
+
+    - name: Fileproxy — install elasticsearch apt repo
+      when: fp_install_fileproxy and fp_elasticsearch_enabled
+      block:
+
+        - name: Ensure apt pre-reqs for elasticsearch repo
+          ansible.builtin.apt:
+            name:
+              - apt-transport-https
+              - gpg
+            state: present
+            update_cache: false
+
+        - name: Install elastic GPG key
+          ansible.builtin.shell: |
+            set -e
+            if [ ! -f /usr/share/keyrings/elasticsearch-keyring.gpg ]; then
+              curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | \
+                gpg --batch --yes --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+            fi
+          args:
+            creates: /usr/share/keyrings/elasticsearch-keyring.gpg
+
+        - name: Add elastic apt source
+          ansible.builtin.copy:
+            dest: /etc/apt/sources.list.d/elastic-{{ fp_elasticsearch_major }}.x.list
+            content: |
+              deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/{{ fp_elasticsearch_major }}.x/apt stable main
+            mode: '0644'
+
+        - name: Install elasticsearch {{ fp_elasticsearch_version }}
+          ansible.builtin.apt:
+            name: elasticsearch={{ fp_elasticsearch_version }}
+            state: present
+            update_cache: true
+            allow_change_held_packages: true
+
+        - name: Hold elasticsearch package at pinned version
+          ansible.builtin.dpkg_selections:
+            name: elasticsearch
+            selection: hold
+
+        - name: Configure elasticsearch for local-only single-node
+          # Matches the behaviour of the file01 docker sidecar: bind loopback,
+          # disable xpack security (no TLS / no auth) — fileproxy is the
+          # only client and runs on the same host.
+          ansible.builtin.copy:
+            dest: /etc/elasticsearch/elasticsearch.yml
+            mode: '0660'
+            owner: root
+            group: elasticsearch
+            content: |
+              cluster.name: edulution-fp
+              node.name: edulution-fp-es
+              network.host: 127.0.0.1
+              http.port: 9200
+              discovery.type: single-node
+              xpack.security.enabled: false
+              xpack.security.enrollment.enabled: false
+              xpack.security.http.ssl.enabled: false
+              xpack.security.transport.ssl.enabled: false
+
+        - name: Enable + start elasticsearch
+          ansible.builtin.systemd:
+            name: elasticsearch
+            enabled: true
+            state: restarted
+            daemon_reload: true
+
+        - name: Wait for elasticsearch to respond
+          ansible.builtin.uri:
+            url: http://127.0.0.1:9200/
+            status_code: 200
+          register: fp_es_ready
+          retries: 30
+          delay: 2
+          until: fp_es_ready.status == 200
+
+    - name: Fileproxy — install edulution-fileproxy package
+      when: fp_install_fileproxy
+      block:
+
+        - name: Install edulution-fileproxy from local .deb
+          ansible.builtin.apt:
+            deb: '{{ fp_deb_path }}'
+          when: fp_deb_path | length > 0
+
+        - name: Install edulution-fileproxy from apt repo
+          ansible.builtin.apt:
+            name: '{{ fp_deb_package }}'
+            state: latest
+            update_cache: true
+          when: fp_deb_path | length == 0
+
+    - name: Fileproxy — secret + config + service
+      when: fp_install_fileproxy
+      block:
+
+        - name: Ensure /etc/edulution-fileproxy exists
+          ansible.builtin.file:
+            path: /etc/edulution-fileproxy
+            state: directory
+            owner: edulution-fileproxy
+            group: edulution-fileproxy
+            mode: '0755'
+
+        - name: Write indexer.secret
+          ansible.builtin.copy:
+            dest: '{{ fp_indexer_secret_path }}'
+            content: '{{ fp_indexer_password }}'
+            owner: edulution-fileproxy
+            group: edulution-fileproxy
+            mode: '0600'
+          no_log: true
+          # Reader strips trailing newlines so editor round-trips are safe.
+
+        - name: Render /etc/edulution-fileproxy/config.yml
+          ansible.builtin.template:
+            src: edulution-fileproxy.config.yml.j2
+            dest: /etc/edulution-fileproxy/config.yml
+            owner: edulution-fileproxy
+            group: edulution-fileproxy
+            mode: '0644'
+          notify: restart edulution-fileproxy
+
+        - name: Enable + start edulution-fileproxy
+          ansible.builtin.systemd:
+            name: edulution-fileproxy
+            enabled: true
+            state: started
+            daemon_reload: true
+
+    # =========================================================================
+    # ABSCHNITT 3 — TRAEFIK /wiki-ROUTE (auf dem Host der Traefik betreibt)
+    # =========================================================================
+    # Traefik hot-reloaded den file-provider bei `watch: true` (default im
+    # edulution-ui-preset). Kein Restart nötig.
+
+    - name: Traefik — install /wiki dynamic route
+      when: fp_install_traefik_route
+      block:
+
+        - name: Ensure traefik config dir exists
+          ansible.builtin.file:
+            path: '{{ fp_traefik_config_dir }}'
+            state: directory
+            mode: '0755'
+
+        - name: Render /wiki traefik route
+          ansible.builtin.template:
+            src: traefik-wiki.yml.j2
+            dest: '{{ fp_traefik_config_dir }}/wiki.yml'
+            mode: '0644'
+          when: fp_traefik_wiki_backend | length > 0
+
+  handlers:
+    - name: restart edulution-fileproxy
+      ansible.builtin.systemd:
+        name: edulution-fileproxy
+        state: restarted

--- a/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
+++ b/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
@@ -32,6 +32,36 @@
 #       }
 #     }
 #   }
+#
+# Multi-Fileserver-Deployment:
+#   Ein Fileproxy-Host, mehrere SMB-Backends. Das Playbook wird dann
+#   MEHRFACH gelauft — einmal pro Rolle:
+#
+#     1. Auf dem Samba-DC:
+#          fp_configure_ad=true, fp_install_fileproxy=false
+#          → Legt AD-User/Gruppe an + setzt valid users für DC-local
+#            Shares (default-school, linuxmuster-global, ...).
+#
+#     2. Auf jedem weiteren Fileserver (file01, file02, file03):
+#          fp_configure_ad=true, fp_install_fileproxy=false
+#          → Idempotency-Check überspringt existierende User/Gruppe.
+#            Der share-grant-Loop setzt valid users nur für Shares
+#            die physisch HIER liegen (net conf getparm path != empty).
+#            Dieselbe `fp_shares`-Liste kann überall durchgereicht
+#            werden; jeder Host grantet nur, was er selbst beherbergt.
+#
+#     3. Auf dem Fileproxy-Host (z.B. 10.0.0.29):
+#          fp_install_fileproxy=true, fp_configure_ad=false
+#          → ES + deb + Config + Systemd. Die shares-Liste enthält
+#            alle Shares mit per-share `server:`-Overrides (s. Beispiel
+#            in vars/edulution-fileproxy_vars.yml).
+#
+#     4. Auf dem Traefik-Host (typisch 10.0.0.4 im edulution-ui-Setup):
+#          fp_install_traefik_route=true, andere Flags false
+#          → Schreibt wiki.yml in die traefik dynamic-config.
+#
+#   Single-Host-Deployment (alle 4 Rollen auf einem Rechner): alle 4
+#   Flags true setzen, einmal laufen lassen.
 # =============================================================================
 
 - name: edulution-fileproxy Installation
@@ -156,15 +186,22 @@
           register: fp_share_valid_users
           changed_when: false
           # A share not in the local registry (DFS proxy on a different
-          # fileserver) silently returns empty; the next step then skips it.
+          # fileserver) silently returns empty; the inner shell below then
+          # skips it via the `net conf getparm path` existence check.
 
         - name: Extend valid users with indexer-readers group
+          # The inner `net conf getparm path` probe is the authoritative
+          # "is this share local to this host" check — shares physically
+          # hosted elsewhere have only msdfs_proxy metadata and no path,
+          # so getparm returns non-zero and the task exits 0 without
+          # touching them. This makes the task safe to run on every
+          # backend host with the full fp_shares list passed; each host
+          # grants only the shares it physically owns.
           ansible.builtin.shell: |
             set -e
             current='{{ item.stdout | trim }}'
-            # Skip shares that aren't local to this DC (DFS proxies register
-            # with different net conf metadata; getparm returns empty for
-            # them).
+            # Skip shares not hosted on this host — DFS-only proxies have
+            # no `path` parameter in the local net conf registry.
             net conf getparm "{{ item.item.name }}" "path" >/dev/null 2>&1 || exit 0
             if echo "$current" | grep -q '{{ fp_indexer_readers_group }}'; then
               echo "already granted"
@@ -178,7 +215,6 @@
           loop: '{{ fp_share_valid_users.results }}'
           loop_control:
             label: '{{ item.item.name }}'
-          when: item.item.server is not defined or item.item.server == fp_smb_default_server
           changed_when: true
 
     # =========================================================================

--- a/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
+++ b/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
@@ -4,14 +4,15 @@
 # =============================================================================
 #
 # Installiert edulution-fileproxy (SMB-proxy + Wiki-HTTP-API) + Elasticsearch
-# + legt den AD-Service-Account an + integriert die Traefik-Route für /wiki.
+# + integriert die Traefik-Route für /wiki.
 #
-# Das Playbook ist in drei unabhängige Abschnitte aufgeteilt, die jeweils
-# per Variable aktiviert werden. Single-Host-Deployment = alle drei true;
-# verteilte Deployment = je Host das passende Flag.
+# Der Indexer nutzt den existierenden global-admin Account — es werden
+# keine eigenen AD-Objekte (User, Gruppen, Share-Grants) angelegt.
+#
+# Das Playbook ist in zwei unabhängige Abschnitte aufgeteilt, die jeweils
+# per Variable aktiviert werden:
 #
 #   fp_install_fileproxy        → ES + Paket + Config + Secret + Systemd
-#   fp_configure_ad             → samba-tool user/group/grants (nur auf dem DC)
 #   fp_install_traefik_route    → dynamic-config-File für Traefik
 #
 # Verwendung:
@@ -23,8 +24,7 @@
 #     "variables": {
 #       "extra_vars": {
 #         "fp_install_fileproxy": true,
-#         "fp_configure_ad": false,
-#         "fp_indexer_password": "...32-char random...",
+#         "fp_indexer_password": "...global-admin password...",
 #         "fp_shares": [
 #           {"name": "default-school"},
 #           {"name": "agy", "server": "10.1.0.2"}
@@ -34,34 +34,19 @@
 #   }
 #
 # Multi-Fileserver-Deployment:
-#   Ein Fileproxy-Host, mehrere SMB-Backends. Das Playbook wird dann
-#   MEHRFACH gelauft — einmal pro Rolle:
+#   Ein Fileproxy-Host, mehrere SMB-Backends:
 #
-#     1. Auf dem Samba-DC:
-#          fp_configure_ad=true, fp_install_fileproxy=false
-#          → Legt AD-User/Gruppe an + setzt valid users für DC-local
-#            Shares (default-school, linuxmuster-global, ...).
-#
-#     2. Auf jedem weiteren Fileserver (file01, file02, file03):
-#          fp_configure_ad=true, fp_install_fileproxy=false
-#          → Idempotency-Check überspringt existierende User/Gruppe.
-#            Der share-grant-Loop setzt valid users nur für Shares
-#            die physisch HIER liegen (net conf getparm path != empty).
-#            Dieselbe `fp_shares`-Liste kann überall durchgereicht
-#            werden; jeder Host grantet nur, was er selbst beherbergt.
-#
-#     3. Auf dem Fileproxy-Host (z.B. 10.0.0.29):
-#          fp_install_fileproxy=true, fp_configure_ad=false
+#     1. Auf dem Fileproxy-Host (z.B. 10.0.0.29):
+#          fp_install_fileproxy=true
 #          → ES + deb + Config + Systemd. Die shares-Liste enthält
 #            alle Shares mit per-share `server:`-Overrides (s. Beispiel
 #            in vars/edulution-fileproxy_vars.yml).
 #
-#     4. Auf dem Traefik-Host (typisch 10.0.0.4 im edulution-ui-Setup):
-#          fp_install_traefik_route=true, andere Flags false
+#     2. Auf dem Traefik-Host (typisch 10.0.0.4 im edulution-ui-Setup):
+#          fp_install_traefik_route=true, fp_install_fileproxy=false
 #          → Schreibt wiki.yml in die traefik dynamic-config.
 #
-#   Single-Host-Deployment (alle 4 Rollen auf einem Rechner): alle 4
-#   Flags true setzen, einmal laufen lassen.
+#   Kein DC-Lauf mehr nötig — global-admin existiert bereits.
 # =============================================================================
 
 - name: edulution-fileproxy Installation
@@ -76,149 +61,20 @@
   tasks:
 
     # =========================================================================
-    # BASELINE SANITY — beide Abschnitte brauchen ein gesetztes Passwort
+    # BASELINE SANITY — global-admin Passwort muss gesetzt sein
     # =========================================================================
 
     - name: Ensure fp_indexer_password is set
       ansible.builtin.assert:
         that:
-          - fp_indexer_password | length >= 12
+          - fp_indexer_password | length >= 1
         fail_msg: |
-          fp_indexer_password must be provided (min 12 chars) via extra_vars.
-          Generate one with:  tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32
-      when: fp_install_fileproxy or fp_configure_ad
+          fp_indexer_password must be provided via extra_vars.
+          This should be the global-admin password from your linuxmuster deployment.
+      when: fp_install_fileproxy
 
     # =========================================================================
-    # ABSCHNITT 1 — AD SERVICE ACCOUNT (nur auf dem Samba-DC laufen lassen)
-    # =========================================================================
-    # Legt den Service-Account + die Gruppe + die share-`valid users`-Grants
-    # an. Idempotent: vorhandene Objekte werden nicht neu erstellt. Erweitert
-    # bestehende `valid users`-Strings additiv, damit andere Grants
-    # (administrator, @SCHOOLS, ...) erhalten bleiben.
-
-    - name: AD — create indexer service user
-      when: fp_configure_ad
-      block:
-
-        - name: Check if indexer service user exists
-          ansible.builtin.command: samba-tool user show {{ fp_indexer_user }}
-          register: fp_user_check
-          changed_when: false
-          failed_when: false
-
-        - name: Create indexer service user
-          ansible.builtin.command: >
-            samba-tool user create {{ fp_indexer_user }} '{{ fp_indexer_password }}'
-            --description="Fileproxy indexer service account"
-            --given-name="Edulution"
-            --surname="Indexer"
-          when: fp_user_check.rc != 0
-          no_log: true
-
-        - name: Ensure password never expires
-          ansible.builtin.command: samba-tool user setexpiry {{ fp_indexer_user }} --noexpiry
-          when: fp_user_check.rc != 0
-          changed_when: true
-
-        - name: Set NOT_DELEGATED flag (userAccountControl=1114624)
-          # NORMAL_ACCOUNT (512) + DONT_EXPIRE_PASSWORD (65536) + NOT_DELEGATED (1048576)
-          ansible.builtin.command: samba-tool user edit {{ fp_indexer_user }}
-          environment:
-            EDITOR: "sed -i 's/^userAccountControl:.*/userAccountControl: 1114624/'"
-          when: fp_user_check.rc != 0
-          changed_when: true
-
-        - name: Rotate password on existing user (when already present)
-          # Idempotent re-run: ensure the secret file and AD stay in sync.
-          ansible.builtin.command: >
-            samba-tool user setpassword {{ fp_indexer_user }}
-            --newpassword='{{ fp_indexer_password }}'
-          when: fp_user_check.rc == 0
-          no_log: true
-          changed_when: true
-
-    - name: AD — create indexer readers group + memberships
-      when: fp_configure_ad
-      block:
-
-        - name: Check if indexer readers group exists
-          ansible.builtin.command: samba-tool group show {{ fp_indexer_readers_group }}
-          register: fp_group_check
-          changed_when: false
-          failed_when: false
-
-        - name: Create indexer readers group
-          ansible.builtin.command: >
-            samba-tool group add {{ fp_indexer_readers_group }}
-            --description="Read-only scope for the fileproxy indexer"
-          when: fp_group_check.rc != 0
-          changed_when: true
-
-        - name: Add service user to indexer readers group (idempotent)
-          ansible.builtin.shell: |
-            samba-tool group addmembers {{ fp_indexer_readers_group }} {{ fp_indexer_user }} 2>&1 | \
-              grep -v 'already a member' || true
-          changed_when: true
-          # On some samba-tool versions the "already a member" status code
-          # is non-zero; grep -v + || true filters the benign case.
-
-        - name: Add service user to global-admins (filesystem bypass for linuxmuster)
-          # linuxmuster breaks NTFS inheritance at every folder level under
-          # per-user homes, so per-folder ACL grants cannot be practically
-          # recursed. global-admins already has OI|CI/FULL on every folder
-          # the linuxmuster setup scripts create — joining the svc account
-          # to this group bypasses the inheritance problem without leaking
-          # interactive credentials. See docs/OPERATOR_RUNBOOK.md
-          # § Indexer service account Step 3b in the fileproxy repo.
-          ansible.builtin.shell: |
-            samba-tool group addmembers global-admins {{ fp_indexer_user }} 2>&1 | \
-              grep -v 'already a member' || true
-          changed_when: true
-
-    - name: AD — share-level valid users (per share hosted locally)
-      when: fp_configure_ad and fp_shares | length > 0
-      block:
-
-        - name: Check each share's current valid users
-          ansible.builtin.shell: |
-            net conf getparm "{{ item.name }}" "valid users" 2>/dev/null || echo ''
-          loop: '{{ fp_shares }}'
-          register: fp_share_valid_users
-          changed_when: false
-          # A share not in the local registry (DFS proxy on a different
-          # fileserver) silently returns empty; the inner shell below then
-          # skips it via the `net conf getparm path` existence check.
-
-        - name: Extend valid users with indexer-readers group
-          # The inner `net conf getparm path` probe is the authoritative
-          # "is this share local to this host" check — shares physically
-          # hosted elsewhere have only msdfs_proxy metadata and no path,
-          # so getparm returns non-zero and the task exits 0 without
-          # touching them. This makes the task safe to run on every
-          # backend host with the full fp_shares list passed; each host
-          # grants only the shares it physically owns.
-          ansible.builtin.shell: |
-            set -e
-            current='{{ item.stdout | trim }}'
-            # Skip shares not hosted on this host — DFS-only proxies have
-            # no `path` parameter in the local net conf registry.
-            net conf getparm "{{ item.item.name }}" "path" >/dev/null 2>&1 || exit 0
-            if echo "$current" | grep -q '{{ fp_indexer_readers_group }}'; then
-              echo "already granted"
-              exit 0
-            fi
-            if [ -z "$current" ]; then
-              net conf setparm "{{ item.item.name }}" "valid users" "@{{ fp_smb_domain }}\\{{ fp_indexer_readers_group }}"
-            else
-              net conf setparm "{{ item.item.name }}" "valid users" "$current,@{{ fp_smb_domain }}\\{{ fp_indexer_readers_group }}"
-            fi
-          loop: '{{ fp_share_valid_users.results }}'
-          loop_control:
-            label: '{{ item.item.name }}'
-          changed_when: true
-
-    # =========================================================================
-    # ABSCHNITT 2 — ELASTICSEARCH + FILEPROXY auf dem Fileproxy-Host
+    # ABSCHNITT 1 — ELASTICSEARCH + FILEPROXY auf dem Fileproxy-Host
     # =========================================================================
 
     - name: Fileproxy — install elasticsearch apt repo
@@ -361,7 +217,7 @@
             daemon_reload: true
 
     # =========================================================================
-    # ABSCHNITT 3 — TRAEFIK /wiki-ROUTE (auf dem Host der Traefik betreibt)
+    # ABSCHNITT 2 — TRAEFIK /wiki-ROUTE (auf dem Host der Traefik betreibt)
     # =========================================================================
     # Traefik hot-reloaded den file-provider bei `watch: true` (default im
     # edulution-ui-preset). Kein Restart nötig.

--- a/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
+++ b/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
@@ -230,12 +230,20 @@
           # Matches the behaviour of the file01 docker sidecar: bind loopback,
           # disable xpack security (no TLS / no auth) — fileproxy is the
           # only client and runs on the same host.
+          #
+          # path.data / path.logs MUST be explicit. The apt package ships an
+          # elasticsearch.yml that already has them, but this module replaces
+          # the file wholesale — omitting them makes ES fall back to compiled
+          # defaults (/usr/share/elasticsearch/{data,logs}) which don't exist
+          # and crash with "Unable to create logs dir" at startup.
           ansible.builtin.copy:
             dest: /etc/elasticsearch/elasticsearch.yml
             mode: '0660'
             owner: root
             group: elasticsearch
             content: |
+              path.data: /var/lib/elasticsearch
+              path.logs: /var/log/elasticsearch
               cluster.name: edulution-fp
               node.name: edulution-fp-es
               network.host: 127.0.0.1

--- a/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
+++ b/edulution-lmninstaller/playbooks/edulution-fileproxy.yml
@@ -4,7 +4,7 @@
 # =============================================================================
 #
 # Installiert edulution-fileproxy (SMB-proxy + Wiki-HTTP-API) + Elasticsearch
-# + integriert die Traefik-Route für /wiki.
+# + integriert die Traefik-Route für die Wiki-API-Endpunkte.
 #
 # Der Indexer nutzt den existierenden global-admin Account — es werden
 # keine eigenen AD-Objekte (User, Gruppen, Share-Grants) angelegt.
@@ -14,6 +14,8 @@
 #
 #   fp_install_fileproxy        → ES + Paket + Config + Secret + Systemd
 #   fp_install_traefik_route    → dynamic-config-File für Traefik
+#                                 (routet /wiki/search + /wiki/list, NICHT
+#                                  den gesamten /wiki-Prefix — siehe unten)
 #
 # Verwendung:
 #   ansible-playbook edulution-fileproxy.yml -e @vars/edulution-fileproxy_vars.yml
@@ -44,7 +46,10 @@
 #
 #     2. Auf dem Traefik-Host (typisch 10.0.0.4 im edulution-ui-Setup):
 #          fp_install_traefik_route=true, fp_install_fileproxy=false
-#          → Schreibt wiki.yml in die traefik dynamic-config.
+#          → Schreibt wiki.yml in die traefik dynamic-config. Die Route matcht
+#            ausschliesslich /wiki/search und /wiki/list. Ein PathPrefix(`/wiki`)
+#            würde die Client-Route der SPA (/wiki/<share>/<pfad>) verdecken und
+#            jeden Wiki-Deeplink beim Reload auf 404 laufen lassen.
 #
 #   Kein DC-Lauf mehr nötig — global-admin existiert bereits.
 # =============================================================================
@@ -217,12 +222,12 @@
             daemon_reload: true
 
     # =========================================================================
-    # ABSCHNITT 2 — TRAEFIK /wiki-ROUTE (auf dem Host der Traefik betreibt)
+    # ABSCHNITT 2 — TRAEFIK-ROUTE FÜR DIE WIKI-API (auf dem Traefik-Host)
     # =========================================================================
     # Traefik hot-reloaded den file-provider bei `watch: true` (default im
     # edulution-ui-preset). Kein Restart nötig.
 
-    - name: Traefik — install /wiki dynamic route
+    - name: Traefik — install the wiki API dynamic route
       when: fp_install_traefik_route
       block:
 
@@ -232,7 +237,7 @@
             state: directory
             mode: '0755'
 
-        - name: Render /wiki traefik route
+        - name: Render the wiki API traefik route
           ansible.builtin.template:
             src: traefik-wiki.yml.j2
             dest: '{{ fp_traefik_config_dir }}/wiki.yml'

--- a/edulution-lmninstaller/playbooks/requirements/edulution-fileproxy.yml
+++ b/edulution-lmninstaller/playbooks/requirements/edulution-fileproxy.yml
@@ -1,0 +1,8 @@
+os:
+  distribution: "Ubuntu"
+  min_version: "24.04"
+ram:
+  min_gb: 4
+disks:
+  min_count: 1
+  min_size_gb: 20

--- a/edulution-lmninstaller/playbooks/templates/edulution-fileproxy.config.yml.j2
+++ b/edulution-lmninstaller/playbooks/templates/edulution-fileproxy.config.yml.j2
@@ -15,11 +15,10 @@ smb:
   session_max_creation_minutes: 30
   session_cleanup_interval: 1
 
-  # Dedicated AD account that the wiki indexer uses for every filesystem
-  # read (PostWriteHook doc body, reindex walk, reconciler scan, search-time
-  # title extraction). REQUIRED when elasticsearch.enabled: true.
-  # See docs/OPERATOR_RUNBOOK.md § Indexer service account (in edulution-fileproxy repo)
-  # for the AD-side setup that makes this user work.
+  # AD account the indexer uses for every filesystem read (PostWriteHook
+  # doc body, reindex walk, reconciler scan, search-time title extraction).
+  # REQUIRED when elasticsearch.enabled: true. Uses the existing global-admin
+  # account — no dedicated AD user or group creation necessary.
   indexer_service_account:
     user: "{{ fp_indexer_user }}"
     password_file: "{{ fp_indexer_secret_path }}"

--- a/edulution-lmninstaller/playbooks/templates/edulution-fileproxy.config.yml.j2
+++ b/edulution-lmninstaller/playbooks/templates/edulution-fileproxy.config.yml.j2
@@ -1,0 +1,47 @@
+# Rendered by the edulution-installer `edulution-fileproxy.yml` playbook.
+# Hand-edits will be overwritten on the next playbook run — change the
+# vars in edulution-fileproxy_vars.yml (or via extra_vars) and re-run.
+
+ldap:
+  server: "ldaps://{{ fp_ldap_server }}:636"
+  insecure_skip_verify: true
+  base_dn: "{{ fp_ldap_base_dn }}"
+
+smb:
+  server: "{{ fp_smb_default_server }}"
+  domain: "{{ fp_smb_domain }}"
+  share_autodiscover: false
+  session_max_idle_minutes: 15
+  session_max_creation_minutes: 30
+  session_cleanup_interval: 1
+
+  # Dedicated AD account that the wiki indexer uses for every filesystem
+  # read (PostWriteHook doc body, reindex walk, reconciler scan, search-time
+  # title extraction). REQUIRED when elasticsearch.enabled: true.
+  # See docs/OPERATOR_RUNBOOK.md § Indexer service account (in edulution-fileproxy repo)
+  # for the AD-side setup that makes this user work.
+  indexer_service_account:
+    user: "{{ fp_indexer_user }}"
+    password_file: "{{ fp_indexer_secret_path }}"
+
+  shares:
+{% for s in fp_shares %}
+    - name: "{{ s.name }}"
+{%   if s.server is defined and s.server %}
+      server: "{{ s.server }}"
+{%   endif %}
+{% endfor %}
+
+http:
+  address: "{{ fp_listen_address }}"
+  webdav_prefix: "{{ fp_webdav_prefix }}"
+  cert_file: "{{ fp_cert_file }}"
+  key_file: "{{ fp_key_file }}"
+
+log:
+  level: "{{ fp_log_level }}"
+  file: "{{ fp_log_file }}"
+
+elasticsearch:
+  enabled: {{ fp_elasticsearch_enabled | to_json }}
+  url: "{{ fp_elasticsearch_url }}"

--- a/edulution-lmninstaller/playbooks/templates/traefik-wiki.yml.j2
+++ b/edulution-lmninstaller/playbooks/templates/traefik-wiki.yml.j2
@@ -1,0 +1,21 @@
+# Rendered by the edulution-installer `edulution-fileproxy.yml` playbook.
+# Routes /wiki/* (the fileproxy's wiki HTTP API — /wiki/roots, /wiki/search,
+# /wiki/tree, /wiki/page) to the production fileproxy backend.
+#
+# Place this file next to the existing webdav.yml + fileproxy.yml in the
+# Traefik file-provider dynamic-config directory. Traefik hot-reloads when
+# watch: true is set in the static config.
+http:
+  routers:
+    wiki:
+      rule: "PathPrefix(`/wiki`)"
+      service: wiki-fileproxy
+      entryPoints:
+        - websecure
+      tls: {}
+
+  services:
+    wiki-fileproxy:
+      loadBalancer:
+        servers:
+          - url: "{{ fp_traefik_wiki_backend }}"

--- a/edulution-lmninstaller/playbooks/templates/traefik-wiki.yml.j2
+++ b/edulution-lmninstaller/playbooks/templates/traefik-wiki.yml.j2
@@ -1,6 +1,22 @@
 # Rendered by the edulution-installer `edulution-fileproxy.yml` playbook.
-# Routes /wiki/* (the fileproxy's wiki HTTP API — /wiki/roots, /wiki/search,
-# /wiki/tree, /wiki/page) to the production fileproxy backend.
+#
+# Routes the two wiki HTTP API endpoints edu-api calls -- /wiki/search and
+# /wiki/list -- to the fileproxy backend.
+#
+# The rule matches those two paths exactly and MUST NOT be widened to
+# PathPrefix(`/wiki`). /wiki is also the edulution SPA's own client-side route
+# (/wiki/<share>/<path>), and Traefik prioritises by rule length, so a prefix
+# rule outranks the catch-all to the frontend and claims the whole subtree. The
+# fileproxy answers only its own endpoints and returns 404 for everything else,
+# so every wiki deep link would 404 on a full page load while in-app navigation
+# kept working. Traefik returns the chosen backend's response as-is -- there is
+# no fall-through to another router on a 404.
+#
+# Path matching is case-sensitive and exact (verified against traefik v3.1), so
+# a wiki page named `Search` or `List` is routed to the SPA and renders
+# normally. A wiki root named exactly lowercase `search` or `list` remains
+# ambiguous; that is the reason edulution-io/edulution-ui#3141 moves the API off
+# this prefix entirely, after which this file can be dropped.
 #
 # Place this file next to the existing webdav.yml + fileproxy.yml in the
 # Traefik file-provider dynamic-config directory. Traefik hot-reloads when
@@ -8,7 +24,7 @@
 http:
   routers:
     wiki:
-      rule: "PathPrefix(`/wiki`)"
+      rule: "Path(`/wiki/search`) || Path(`/wiki/list`)"
       service: wiki-fileproxy
       entryPoints:
         - websecure

--- a/edulution-lmninstaller/playbooks/vars/edulution-fileproxy_vars.yml
+++ b/edulution-lmninstaller/playbooks/vars/edulution-fileproxy_vars.yml
@@ -12,14 +12,9 @@
 # ROLE-GATING
 # -----------------------------------------------------------------------------
 # Aktiviere die Aufgaben-Blöcke, die auf dem aktuellen Host laufen sollen.
-# Bei Single-Host-Deployment (DC + fileproxy auf einem Rechner) beide true.
 
 # Installiert Elasticsearch + edulution-fileproxy + schreibt Config + Secret.
 fp_install_fileproxy: true
-
-# Legt den AD-Service-Account an, die Gruppe, die Rechte + die share-level
-# `valid users`-Grants. NUR auf dem Samba-DC true setzen.
-fp_configure_ad: false
 
 # Schreibt die Traefik `/wiki`-Route in die dynamic-config. Aktiviere auf dem
 # Host, der Traefik für die edulution-Front betreibt (meist 10.0.0.x wo
@@ -79,17 +74,16 @@ fp_smb_domain: 'LINUXMUSTER'
 fp_shares: []
 
 # -----------------------------------------------------------------------------
-# INDEXER SERVICE ACCOUNT (AD)
+# INDEXER ACCOUNT
 # -----------------------------------------------------------------------------
 
-fp_indexer_user: 'edulution-indexer-svc'
-fp_indexer_readers_group: 'edulution-indexer-readers'
+# AD-Benutzer für den Indexer. Default: global-admin (existiert bereits in
+# jeder linuxmuster-Installation, keine zusätzlichen AD-Objekte nötig).
+fp_indexer_user: 'global-admin'
 
-# Passwort für den Service-Account. MUSS per extra_vars gesetzt werden, kein
-# Default — das Passwort wird sowohl im AD als auch in /etc/edulution-fileproxy/indexer.secret
-# abgelegt, beide müssen übereinstimmen.
-# Beim fp_configure_ad-Block wird dieses Passwort in samba-tool user create/setpassword
-# genutzt; beim fp_install_fileproxy-Block landet es im 0600-secret-File.
+# Passwort des Indexer-Accounts (= global-admin Passwort). MUSS per extra_vars
+# gesetzt werden, kein Default. Wird in /etc/edulution-fileproxy/indexer.secret
+# abgelegt (mode 0600).
 fp_indexer_password: ''
 
 # Wohin die Secret-Datei geschrieben wird.

--- a/edulution-lmninstaller/playbooks/vars/edulution-fileproxy_vars.yml
+++ b/edulution-lmninstaller/playbooks/vars/edulution-fileproxy_vars.yml
@@ -1,0 +1,126 @@
+# =============================================================================
+# EDULUTION-FILEPROXY - KONFIGURATIONSVARIABLEN
+# =============================================================================
+#
+# Verwendung:
+#   ansible-playbook edulution-fileproxy.yml -e @vars/edulution-fileproxy_vars.yml
+#
+# Oder via API mit extra_vars.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# ROLE-GATING
+# -----------------------------------------------------------------------------
+# Aktiviere die Aufgaben-Blöcke, die auf dem aktuellen Host laufen sollen.
+# Bei Single-Host-Deployment (DC + fileproxy auf einem Rechner) beide true.
+
+# Installiert Elasticsearch + edulution-fileproxy + schreibt Config + Secret.
+fp_install_fileproxy: true
+
+# Legt den AD-Service-Account an, die Gruppe, die Rechte + die share-level
+# `valid users`-Grants. NUR auf dem Samba-DC true setzen.
+fp_configure_ad: false
+
+# Schreibt die Traefik `/wiki`-Route in die dynamic-config. Aktiviere auf dem
+# Host, der Traefik für die edulution-Front betreibt (meist 10.0.0.x wo
+# edulution-ui + edulution-api Container laufen).
+fp_install_traefik_route: false
+
+# -----------------------------------------------------------------------------
+# ELASTICSEARCH
+# -----------------------------------------------------------------------------
+
+# Major-Version (matcht das docker-sidecar-image auf bestehenden Sites).
+fp_elasticsearch_major: '8'
+fp_elasticsearch_version: '8.19.3'
+
+# Wiki endpoints im Fileproxy (/wiki/roots, /wiki/search, ...) benötigen ES.
+# Auf false nur wenn du WebDAV ohne Wiki deployst.
+fp_elasticsearch_enabled: true
+fp_elasticsearch_url: 'http://127.0.0.1:9200'
+
+# -----------------------------------------------------------------------------
+# FILEPROXY BINARY
+# -----------------------------------------------------------------------------
+
+# Pfad zu einem .deb-File wenn du lokal bootstrappen willst (bypasses apt repo).
+# Leer lassen um aus dem konfigurierten apt-repo zu ziehen.
+fp_deb_path: ''
+
+# Name des Pakets im apt-repo.
+fp_deb_package: 'edulution-fileproxy'
+
+# -----------------------------------------------------------------------------
+# LDAP (für ACL-Evaluation im Fileproxy)
+# -----------------------------------------------------------------------------
+
+fp_ldap_server: '10.0.0.1'
+fp_ldap_base_dn: 'DC=linuxmuster,DC=lan'
+
+# -----------------------------------------------------------------------------
+# SMB BACKEND-KONFIGURATION
+# -----------------------------------------------------------------------------
+
+# Default-SMB-Server wenn eine Share keine eigene `server`-Einstellung hat.
+fp_smb_default_server: '10.0.0.1'
+fp_smb_domain: 'LINUXMUSTER'
+
+# Shares die der Fileproxy exposed. Jeder Share kann einen `server`-Override
+# haben (per-share fileserver in multi-fileserver-Deployments) — siehe
+# docs/OPERATOR_RUNBOOK.md § Multi-fileserver deployments im fileproxy-repo.
+#
+# Beispiel:
+# fp_shares:
+#   - { name: 'default-school' }
+#   - { name: 'linuxmuster-global' }
+#   - { name: 'agy', server: '10.1.0.2' }
+#   - { name: 'brs', server: '10.2.0.2' }
+#   - { name: 'cgs', server: '10.3.0.2' }
+fp_shares: []
+
+# -----------------------------------------------------------------------------
+# INDEXER SERVICE ACCOUNT (AD)
+# -----------------------------------------------------------------------------
+
+fp_indexer_user: 'edulution-indexer-svc'
+fp_indexer_readers_group: 'edulution-indexer-readers'
+
+# Passwort für den Service-Account. MUSS per extra_vars gesetzt werden, kein
+# Default — das Passwort wird sowohl im AD als auch in /etc/edulution-fileproxy/indexer.secret
+# abgelegt, beide müssen übereinstimmen.
+# Beim fp_configure_ad-Block wird dieses Passwort in samba-tool user create/setpassword
+# genutzt; beim fp_install_fileproxy-Block landet es im 0600-secret-File.
+fp_indexer_password: ''
+
+# Wohin die Secret-Datei geschrieben wird.
+fp_indexer_secret_path: '/etc/edulution-fileproxy/indexer.secret'
+
+# -----------------------------------------------------------------------------
+# HTTP LISTENER
+# -----------------------------------------------------------------------------
+
+fp_listen_address: ':443'
+fp_webdav_prefix: '/webdav/'
+fp_cert_file: '/etc/edulution-fileproxy/webdav.pem'
+fp_key_file: '/etc/edulution-fileproxy/webdav.key'
+
+# -----------------------------------------------------------------------------
+# LOGGING
+# -----------------------------------------------------------------------------
+
+fp_log_level: 'info'
+fp_log_file: '/var/log/edulution-fileproxy/server.log'
+
+# -----------------------------------------------------------------------------
+# TRAEFIK INTEGRATION
+# -----------------------------------------------------------------------------
+
+# Pfad zur Traefik dynamic-config (file-provider). Default passt zum
+# edulution-ui-docker-compose-Setup.
+fp_traefik_config_dir: '/srv/docker/edulution-ui/data/traefik/config'
+
+# URL die Traefik als Backend für die /wiki-Route verwendet. Das ist die
+# externe Adresse des Fileproxy-Hosts, NICHT localhost — Traefik läuft in
+# einem eigenen Container.
+# Beispiel: 'https://10.0.0.29:443'
+fp_traefik_wiki_backend: ''

--- a/edulution-lmninstaller/playbooks/vars/edulution-fileproxy_vars.yml
+++ b/edulution-lmninstaller/playbooks/vars/edulution-fileproxy_vars.yml
@@ -16,7 +16,7 @@
 # Installiert Elasticsearch + edulution-fileproxy + schreibt Config + Secret.
 fp_install_fileproxy: true
 
-# Schreibt die Traefik `/wiki`-Route in die dynamic-config. Aktiviere auf dem
+# Schreibt die Traefik-Route für die Wiki-API in die dynamic-config. Aktiviere auf dem
 # Host, der Traefik für die edulution-Front betreibt (meist 10.0.0.x wo
 # edulution-ui + edulution-api Container laufen).
 fp_install_traefik_route: false
@@ -113,7 +113,7 @@ fp_log_file: '/var/log/edulution-fileproxy/server.log'
 # edulution-ui-docker-compose-Setup.
 fp_traefik_config_dir: '/srv/docker/edulution-ui/data/traefik/config'
 
-# URL die Traefik als Backend für die /wiki-Route verwendet. Das ist die
+# URL die Traefik als Backend für die Wiki-API-Route verwendet. Das ist die
 # externe Adresse des Fileproxy-Hosts, NICHT localhost — Traefik läuft in
 # einem eigenen Container.
 # Beispiel: 'https://10.0.0.29:443'


### PR DESCRIPTION
## Summary

New Ansible playbook that automates the edulution-fileproxy stack end-to-end — what the fileproxy's `docs/OPERATOR_RUNBOOK.md` describes as manual copy-paste steps becomes one `ansible-playbook` invocation with extra_vars.

The indexer uses the existing `global-admin` account, so the playbook creates **no** AD objects (users, groups or share grants). Two role-gating flags let the same playbook cover every deployment shape:

| Flag | Host it runs on | What it does |
|---|---|---|
| `fp_install_fileproxy` | Fileproxy host | Adds the Elastic apt repo → installs Elasticsearch 8.19.3 (pinned + held, gated by `fp_elasticsearch_enabled`) → configures a single-node bind to 127.0.0.1 → installs the edulution-fileproxy deb → writes `indexer.secret` (0600) → renders `config.yml` from the Jinja template → enables + starts the systemd unit |
| `fp_install_traefik_route` | Traefik host | Drops `wiki.yml` into the dynamic-config dir so the wiki API endpoints route to the configured fileproxy backend |

Single-host sites set both true; distributed sites run the same playbook once per host with the appropriate flag.

## The Traefik route matches two exact paths, not the `/wiki` prefix

`wiki.yml` routes **only** `/wiki/search` and `/wiki/list`:

```yaml
rule: "Path(`/wiki/search`) || Path(`/wiki/list`)"
```

It must not be widened to `PathPrefix(/wiki)`. `/wiki` is also the edulution SPA's own client-side route (`/wiki/<share>/<path>`), and Traefik prioritises by rule length — so a prefix rule outranks the catch-all to the frontend and is handed the whole subtree. The fileproxy serves its own endpoints and returns 404 for everything else, and Traefik returns the selected backend's response verbatim (no fall-through to another router on a 404). The result is that every wiki deep link 404s on a full page load while in-app navigation keeps working — [edulution-io/edulution-ui#3141](https://github.com/edulution-io/edulution-ui/issues/3141).

`search` and `list` are the only two endpoints edu-api calls. `/wiki/roots` and `/wiki/tree` lost their last caller in edulution-ui v2.0.156, and `/wiki/page` was removed from the fileproxy. `Path` matching is case-sensitive and exact (verified against a real `traefik:v3.1` container), so a wiki page named `Search` or `List` routes to the SPA and renders; only a wiki root named exactly lowercase `search` or `list` stays ambiguous. That residual case is why #3141 moves the API off the prefix altogether, after which this route can be dropped.

## Files

- `playbooks/edulution-fileproxy.yml` — main playbook (251 LOC)
- `playbooks/vars/edulution-fileproxy_vars.yml` — all `fp_*` defaults with comments
- `playbooks/templates/edulution-fileproxy.config.yml.j2` — renders `/etc/edulution-fileproxy/config.yml`
- `playbooks/templates/traefik-wiki.yml.j2` — renders the Traefik route for the wiki API
- `playbooks/requirements/edulution-fileproxy.yml` — min OS + RAM + disk
- `README.md` — "Available playbooks" table

## Idempotency

Every step is re-run-safe:

- `apt.deb` / `apt.name` idempotent by default
- `dpkg_selections` holds ES at the pinned version
- the ES `elasticsearch.yml`, the fileproxy `config.yml`, `indexer.secret` and `wiki.yml` are rendered from templates, so a re-run converges rather than appends
- `systemd` `enabled: true` / `state: started` are declarative

## Test plan

- [ ] Dry-run syntax: `ansible-playbook --syntax-check edulution-fileproxy.yml` (local YAML load passes; syntax-check needs ansible installed, unavailable in this environment)
- [ ] Single-host: apply with both flags on a fresh Ubuntu 24.04 VM
- [ ] Confirm a wiki deep link renders: `curl -sk -o /dev/null -w '%{http_code}' https://<ui-host>/wiki/Home` returns **200** (the SPA), not 404
- [ ] Confirm the API is still routed: `curl -sk -o /dev/null -w '%{http_code}' https://<ui-host>/wiki/search` returns **401** (auth required), not 404
- [ ] Re-run the same playbook; every step reports "ok" not "changed" (idempotency)
- [ ] Fileproxy startup log shows the indexer wired with `service_account=global-admin servers=[...]`
- [ ] Multi-fileserver: add `fp_shares: [{name: agy, server: 10.1.0.2}, ...]`; confirm the startup log lists the unique servers

## Known follow-ups (not blocking)

- **`api_prefix` is not in the config template.** `edulution-fileproxy.config.yml.j2` renders the `http` block with `address`, `webdav_prefix`, `cert_file` and `key_file` only, and the template overwrites `config.yml` on every run. Once [edulution-io/edulution-fileproxy#62](https://github.com/edulution-io/edulution-fileproxy/pull/62) lands (it moves the wiki API to `/edu-fileproxy/wiki`), a hand-added `api_prefix` would be deleted on the next playbook run. Needs an `api_prefix: "{{ fp_api_prefix }}"` line plus an `fp_api_prefix` default matching the fileproxy's built-in default.
- **`api/services/ansible_runner.py:114-118` stages only the playbook file** into the ansible-runner project dir, not `playbooks/vars/` or `playbooks/templates/`. This playbook resolves `vars_files` and `template: src:` relative to its own directory, so an API-triggered run fails on `vars_files`. `bootstrap.sh` does download `vars/` and `templates/` to the host, so the gap is purely in the runner's project staging — a ~5-line fix, and a prerequisite for running this playbook through the API at all.

## Related

Pairs with [edulution-io/edulution-ui#3141](https://github.com/edulution-io/edulution-ui/issues/3141) (wiki deep-link 404) and its fileproxy counterpart [edulution-io/edulution-fileproxy#62](https://github.com/edulution-io/edulution-fileproxy/pull/62), plus the fileproxy documentation:

- `docs/OPERATOR_RUNBOOK.md` § Indexer service account
- `docs/OPERATOR_RUNBOOK.md` § Multi-fileserver deployments
- `docs/OPERATOR_RUNBOOK.md` § Reverse-proxy (Traefik) integration