### PR TITLE
Same-machine linuxmuster install + install/setup fixes

### DIFF
--- a/apps/public-page/public/installer
+++ b/apps/public-page/public/installer
@@ -174,6 +174,22 @@ DOCKEREOF
     echo "[*] Docker Daemon konfiguriert."
 fi
 
+# SSH-Freigabe fuer den edulution-Installer (nur localhost + Docker-Bridge-Netz).
+# Muss bereits vor dem Start des Installer-Containers existieren: bei einer
+# "gleiche Maschine"-Installation greift der Container per SSH ueber die
+# docker0-IP auf den Host zu (der linuxmuster-Bootstrap laeuft dann lokal auf
+# diesem Host). Das Playbook legt die Datei spaeter zwar erneut an, das ist fuer
+# den initialen Bootstrap aber zu spaet.
+echo "[*] Konfiguriere SSH-Zugriff fuer den edulution-Installer (localhost + Docker-Netz)..."
+mkdir -p /etc/ssh/sshd_config.d
+cat <<'SSHEOF' > /etc/ssh/sshd_config.d/edulution_installer.conf
+Match Address 127.0.0.1,172.17.0.0/16
+    PermitRootLogin yes
+    PasswordAuthentication yes
+SSHEOF
+chmod 0644 /etc/ssh/sshd_config.d/edulution_installer.conf
+systemctl restart ssh 2>/dev/null || systemctl restart sshd 2>/dev/null || true
+
 if ! command -v jq &> /dev/null; then
     echo "[*] JQ ist nicht installiert. Installation wird gestartet..."
     apt-get update

--- a/apps/webinstaller-api/app/main.py
+++ b/apps/webinstaller-api/app/main.py
@@ -70,6 +70,8 @@ class ConfigurationRequest(BaseModel):
     lmnLdapSchema: str
     lmnLdapPort: int
     edulutionExternalDomain: str
+    lmnLocalInstall: bool = False
+    lmnWebuiPort: int = 8443
 
 
 class AdminGroupRequest(BaseModel):
@@ -163,6 +165,8 @@ class Data:
         self.DATA_DEPLOYMENT_TARGET = None
         self.DATA_INITIAL_ADMIN_GROUP = None
         self.DATA_LMN_TARGET_HOST = None
+        self.DATA_LMN_LOCAL_INSTALL = False
+        self.DATA_LMN_WEBUI_PORT = 443
 
 
 data = Data()
@@ -212,6 +216,10 @@ def configure(config: ConfigurationRequest, data: Data = Depends(getData)):
     data.DATA_LMN_LDAP_SCHEMA = config.lmnLdapSchema
     data.DATA_LMN_LDAP_PORT = config.lmnLdapPort
     data.DATA_EDULUTION_EXTERNAL_DOMAIN = config.edulutionExternalDomain
+    data.DATA_LMN_LOCAL_INSTALL = config.lmnLocalInstall
+    # Ajenti/webdav bleibt auf 443, ausser bei "gleiche Maschine": dort weicht
+    # die linuxmuster-Web-UI dem edulution-Traefik auf lmnWebuiPort aus.
+    data.DATA_LMN_WEBUI_PORT = config.lmnWebuiPort if config.lmnLocalInstall else 443
     return {"status": True, "message": "Konfiguration gespeichert"}
 
 
@@ -237,7 +245,9 @@ def checkAPIStatus(data: Data = Depends(getData)):
 def checkWebDAV(data: Data = Depends(getData)):
     try:
         result = requests.get(
-            "https://" + data.DATA_LMN_EXTERNAL_DOMAIN + ":443", verify=False, timeout=3
+            "https://" + data.DATA_LMN_EXTERNAL_DOMAIN + ":" + str(data.DATA_LMN_WEBUI_PORT),
+            verify=False,
+            timeout=3,
         )
         if result.status_code == 200:
             return {"status": True, "message": "Successful"}
@@ -318,6 +328,27 @@ def setAdminGroup(req: AdminGroupRequest, data: Data = Depends(getData)):
 @api.get("/proxy-check")
 def proxyCheck(request: Request):
     return {"proxyDetected": request.headers.get("x-forwarded-for") is not None}
+
+
+@api.get("/docker-host-ip")
+def dockerHostIp():
+    # The container's default gateway is the docker bridge (docker0) address on
+    # the host. In "same machine" mode this is how edulution reaches the LMN
+    # server running on the host.
+    try:
+        with open("/proc/net/route") as f:
+            for line in f.readlines()[1:]:
+                fields = line.strip().split()
+                # Destination 00000000 == default route; field[2] is the gateway
+                if len(fields) >= 3 and fields[1] == "00000000":
+                    gw_hex = fields[2]
+                    ip = ".".join(
+                        str(int(gw_hex[i : i + 2], 16)) for i in (6, 4, 2, 0)
+                    )
+                    return {"ip": ip}
+    except Exception as e:
+        print(e)
+    return {"ip": "172.17.0.1"}
 
 
 @api.post("/create-ss-certificate")
@@ -699,6 +730,16 @@ def generateRandom(length=5):
 def createEdulutionEnvFile(data: Data):
     root_dn = re.search(r"(DC=.*$)", data.DATA_LMN_BINDUSER_DN).group(1)
 
+    # Ajenti serves the LMN webdav. On a "same machine" install it is moved off
+    # 443 (which the edulution Traefik occupies), so webdav must be addressed on
+    # the new port. On 443 the netloc stays bare to preserve prior behaviour.
+    webdav_port = data.DATA_LMN_WEBUI_PORT or 443
+    webdav_netloc = (
+        data.DATA_LMN_EXTERNAL_DOMAIN
+        if webdav_port == 443
+        else f"{data.DATA_LMN_EXTERNAL_DOMAIN}:{webdav_port}"
+    )
+
     keycloak_eduapi_secret = generateSecret()
     keycloak_eduui_secret = generateSecret()
     keycloak_edumailcow_sync_secret = generateSecret()
@@ -771,7 +812,7 @@ def createEdulutionEnvFile(data: Data):
 EDUI_ORGANIZATION_TYPE={data.DATA_ORGANIZATION_TYPE}
 EDUI_DEPLOYMENT_TARGET={data.DATA_DEPLOYMENT_TARGET}
 
-EDUI_WEBDAV_URL=https://{data.DATA_LMN_EXTERNAL_DOMAIN}/webdav/
+EDUI_WEBDAV_URL=https://{webdav_netloc}/webdav/
 
 MONGODB_USERNAME=root
 MONGODB_PASSWORD={mongodb_secret}
@@ -875,7 +916,7 @@ http:
     webdav:
       loadBalancer:
         servers:
-          - url: "https://{data.DATA_LMN_EXTERNAL_DOMAIN}/webdav"
+          - url: "https://{webdav_netloc}/webdav"
 """
 
     with open("/edulution-ui/data/traefik/config/webdav.yml", "w") as f:

--- a/apps/webinstaller/src/api/installerApi.ts
+++ b/apps/webinstaller/src/api/installerApi.ts
@@ -14,6 +14,8 @@ interface ConfigurationRequest {
   lmnLdapSchema: 'ldap' | 'ldaps';
   lmnLdapPort: number;
   edulutionExternalDomain: string;
+  lmnLocalInstall: boolean;
+  lmnWebuiPort: number;
 }
 
 interface SsCertificateRequest {
@@ -108,6 +110,11 @@ export const startInstallation = (): Promise<StatusResponse> =>
 
 export const checkProxy = (): Promise<{ proxyDetected: boolean }> =>
   apiFetch<{ proxyDetected: boolean }>('/api/proxy-check');
+
+// docker0 gateway IP as seen from inside the edulution container.
+// Used in "same machine" mode as the address to reach the LMN server on the host.
+export const getDockerHostIp = (): Promise<{ ip: string }> =>
+  apiFetch<{ ip: string }>('/api/docker-host-ip');
 
 // --- LMN Installer API ---
 

--- a/apps/webinstaller/src/i18n/locales/de/translation.json
+++ b/apps/webinstaller/src/i18n/locales/de/translation.json
@@ -123,6 +123,7 @@
   "lmnConfig": {
     "title": "linuxmuster.net Konfiguration (Schritt {{step}}/2)",
     "network": "Netzwerk",
+    "networkAutoDetected": "Netzwerk (Server-IP, Netzmaske, Gateway) wird auf dieser Maschine automatisch übernommen.",
     "serverIp": "Server-IP:",
     "subnetMask": "Subnetzmaske:",
     "gateway": "Gateway:",

--- a/apps/webinstaller/src/i18n/locales/de/translation.json
+++ b/apps/webinstaller/src/i18n/locales/de/translation.json
@@ -38,7 +38,9 @@
     "descriptionGeneric": "Hier kann ein Verzeichnisdienst mit Active Directory angebunden werden.",
     "enterToken": "Füge hier deinen edulution Setup-Token ein:",
     "manualEntryLabel": "Hier gehts zur manuellen Eingabe:",
-    "manualEntry": "Manuell eingeben"
+    "manualEntry": "Manuell eingeben",
+    "localInstall": "Auf dieser Maschine installieren",
+    "localInstallHint": "Der linuxmuster.net-Server wird auf derselben Maschine wie edulution installiert. Als Adresse wird die docker0-IP verwendet und die linuxmuster-Web-UI (Ajenti) auf einen anderen Port verschoben."
   },
   "configure": {
     "externalDomainLmn": "Externe Domain des linuxmuster.net-Servers:",
@@ -100,6 +102,7 @@
     "reqRam": "Mindestens 4 GB RAM",
     "reqDisks": "Mindestens 2 Festplatten mit je 25 GB",
     "sshHost": "SSH Host:",
+    "localInstallHostHint": "Gleiche Maschine: automatisch auf die docker0-IP des Hosts gesetzt.",
     "sshPort": "SSH Port:",
     "sshUser": "SSH Benutzer:",
     "sshPassword": "SSH Passwort:",

--- a/apps/webinstaller/src/i18n/locales/en/translation.json
+++ b/apps/webinstaller/src/i18n/locales/en/translation.json
@@ -123,6 +123,7 @@
   "lmnConfig": {
     "title": "linuxmuster.net Configuration (Step {{step}}/2)",
     "network": "Network",
+    "networkAutoDetected": "Network (server IP, subnet mask, gateway) is applied automatically on this machine.",
     "serverIp": "Server IP:",
     "subnetMask": "Subnet mask:",
     "gateway": "Gateway:",

--- a/apps/webinstaller/src/i18n/locales/en/translation.json
+++ b/apps/webinstaller/src/i18n/locales/en/translation.json
@@ -38,7 +38,9 @@
     "descriptionGeneric": "Here you can connect a directory service with Active Directory.",
     "enterToken": "Enter your edulution setup token here:",
     "manualEntryLabel": "Go to manual configuration:",
-    "manualEntry": "Enter manually"
+    "manualEntry": "Enter manually",
+    "localInstall": "Install on this machine",
+    "localInstallHint": "The linuxmuster.net server is installed on the same machine as edulution. The docker0 IP is used as its address and the linuxmuster web UI (Ajenti) is moved to a different port."
   },
   "configure": {
     "externalDomainLmn": "External domain of the linuxmuster.net server:",
@@ -100,6 +102,7 @@
     "reqRam": "At least 4 GB RAM",
     "reqDisks": "At least 2 disks with 25 GB each",
     "sshHost": "SSH Host:",
+    "localInstallHostHint": "Same machine: automatically set to the host's docker0 IP.",
     "sshPort": "SSH Port:",
     "sshUser": "SSH User:",
     "sshPassword": "SSH Password:",

--- a/apps/webinstaller/src/pages/ConfigurePage.tsx
+++ b/apps/webinstaller/src/pages/ConfigurePage.tsx
@@ -70,6 +70,8 @@ const ConfigurePage = () => {
         lmnLdapSchema,
         lmnLdapPort,
         edulutionExternalDomain,
+        lmnLocalInstall: store.lmnLocalInstall,
+        lmnWebuiPort: store.lmnWebuiPort,
       });
       void navigate('/check');
     } catch {

--- a/apps/webinstaller/src/pages/LmnConfigPage.tsx
+++ b/apps/webinstaller/src/pages/LmnConfigPage.tsx
@@ -54,12 +54,16 @@ const LmnConfigPage = () => {
   const [timezone, setTimezone] = useState(store.lmnTimezone);
   const [locale, setLocale] = useState(store.lmnLocale);
 
+  // Bei "gleiche Maschine" ist das Netzwerk des Hosts bereits korrekt konfiguriert.
+  // Server-IP/Netzmaske/Gateway werden dann automatisch erkannt und nicht abgefragt.
+  const isLocal = store.lmnLocalInstall;
+
   useEffect(() => {
     void getLmnNetworkInfo()
       .then((info) => {
-        if (info.ip && !serverIp) setServerIp(info.ip);
-        if (info.netmask && !netmask) setNetmask(info.netmask);
-        if (info.gateway && !gateway) setGateway(info.gateway);
+        if (info.ip && (!serverIp || isLocal)) setServerIp(info.ip);
+        if (info.netmask && (!netmask || isLocal)) setNetmask(info.netmask);
+        if (info.gateway && (!gateway || isLocal)) setGateway(info.gateway);
         if (info.hostname && !servername) setServername(info.hostname);
       })
       .catch(() => {
@@ -71,9 +75,7 @@ const LmnConfigPage = () => {
   const pwMatch = adminpw === adminpwConfirm;
 
   const step1Valid =
-    isValidIp(serverIp) &&
-    isValidIp(netmask) &&
-    isValidIp(gateway) &&
+    (isLocal || (isValidIp(serverIp) && isValidIp(netmask) && isValidIp(gateway))) &&
     servername.trim() !== '' &&
     domainname.trim() !== '';
 
@@ -107,9 +109,16 @@ const LmnConfigPage = () => {
 
       {step === 1 && (
         <>
-          {/* Netzwerk */}
-          <h4 className="text-sm font-bold text-gray-600">{t('lmnConfig.network')}</h4>
-          <div className="grid grid-cols-3 gap-3">
+          {/* Netzwerk – bei gleicher Maschine bereits korrekt konfiguriert, daher ausgeblendet */}
+          {isLocal && (
+            <div className="rounded-lg bg-blue-50 p-3 text-sm text-blue-800">
+              {t('lmnConfig.networkAutoDetected')}
+            </div>
+          )}
+          {!isLocal && (
+            <>
+              <h4 className="text-sm font-bold text-gray-600">{t('lmnConfig.network')}</h4>
+              <div className="grid grid-cols-3 gap-3">
             <div>
               <label
                 htmlFor="lmn_server_ip"
@@ -156,6 +165,8 @@ const LmnConfigPage = () => {
               />
             </div>
           </div>
+            </>
+          )}
 
           {/* Server */}
           <h4 className="text-sm font-bold text-gray-600">{t('lmnConfig.server')}</h4>

--- a/apps/webinstaller/src/pages/LmnInstallPage.tsx
+++ b/apps/webinstaller/src/pages/LmnInstallPage.tsx
@@ -109,6 +109,8 @@ const LmnInstallPage = () => {
         lmn_adminpw: currentStore.lmnAdminpw,
         lmn_timezone: currentStore.lmnTimezone,
         lmn_locale: currentStore.lmnLocale,
+        lmn_local_install: currentStore.lmnLocalInstall,
+        lmn_webui_port: currentStore.lmnWebuiPort,
       });
     } catch {
       store.appendLmnOutput(t('lmnInstall.playbookError'));
@@ -170,6 +172,8 @@ const LmnInstallPage = () => {
         lmnLdapSchema: currentStore.lmnLdapSchema,
         lmnLdapPort: currentStore.lmnLdapPort,
         edulutionExternalDomain: currentStore.edulutionExternalDomain,
+        lmnLocalInstall: currentStore.lmnLocalInstall,
+        lmnWebuiPort: currentStore.lmnWebuiPort,
       });
     } catch {
       // Store already has values, continue anyway

--- a/apps/webinstaller/src/pages/LmnSetupPage.tsx
+++ b/apps/webinstaller/src/pages/LmnSetupPage.tsx
@@ -6,7 +6,7 @@ import { Input } from '@shared-ui';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner, faCircleCheck, faCircleXmark, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import useInstallerStore from '../store/useInstallerStore';
-import { bootstrapLmnServer, checkLmnRequirements, checkLmnConnection } from '../api/installerApi';
+import { bootstrapLmnServer, checkLmnRequirements, checkLmnConnection, getDockerHostIp } from '../api/installerApi';
 import type { RequirementsResponse } from '../api/installerApi';
 import StatusCard from '../components/StatusCard';
 
@@ -36,6 +36,24 @@ const LmnSetupPage = () => {
   useEffect(() => () => {
     if (cleanupRef.current) cleanupRef.current();
   }, []);
+
+  // In "same machine" mode the LMN server runs on the docker host, reachable
+  // from this container via the docker0 gateway IP. Prefill and lock the host.
+  useEffect(() => {
+    if (!store.lmnLocalInstall) return;
+    void getDockerHostIp()
+      .then((info) => {
+        if (info.ip) {
+          setHost(info.ip);
+          store.setLmnSsh({ host: info.ip, port, user, password });
+        }
+      })
+      .catch(() => {
+        // Fall back to the default docker bridge gateway
+        setHost('172.17.0.1');
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store.lmnLocalInstall]);
 
   const isValidSsh = host.trim() !== '' && port > 0 && port <= 65535 && user.trim() !== '' && password.trim() !== '';
 
@@ -124,8 +142,11 @@ const LmnSetupPage = () => {
           value={host}
           onChange={(e) => setHost(e.target.value)}
           className={host.trim() ? 'valid-input' : ''}
-          disabled={bootstrapRunning}
+          disabled={bootstrapRunning || store.lmnLocalInstall}
         />
+        {store.lmnLocalInstall && (
+          <p className="mt-1 text-xs text-gray-500">{t('lmnSetup.localInstallHostHint')}</p>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-4">

--- a/apps/webinstaller/src/pages/TokenPage.tsx
+++ b/apps/webinstaller/src/pages/TokenPage.tsx
@@ -19,6 +19,7 @@ const TokenPage = () => {
   const [step, setStep] = useState<Step>('adType');
   const [adType, setAdType] = useState<'existing' | 'new' | ''>(store.adType ?? '');
   const [target, setTarget] = useState<DeploymentTarget>(store.deploymentTarget ?? 'linuxmuster');
+  const [localInstall, setLocalInstall] = useState(store.lmnLocalInstall);
 
   const [token, setToken] = useState('');
   const [tokenValid, setTokenValid] = useState(false);
@@ -70,8 +71,9 @@ const TokenPage = () => {
   const handleNewAd = useCallback(() => {
     store.setAdType('new');
     store.setDeploymentTarget('linuxmuster');
+    store.setLmnLocalInstall(localInstall);
     void navigate('/lmn-setup');
-  }, [store, navigate]);
+  }, [store, navigate, localInstall]);
 
   const handleNext = useCallback(() => {
     if (!adType) return;
@@ -156,15 +158,35 @@ const TokenPage = () => {
           </div>
         )}
 
-        {target === 'linuxmuster' ? (
-          <p className="mt-2 text-sm text-gray-600">
-            {t('token.descriptionLinuxmuster')}
-          </p>
-        ) : (
-          <p className="mt-2 text-sm text-gray-600">
-            {t('token.descriptionGeneric')}
-          </p>
+        {adType === 'new' && (
+          <div className="rounded-lg bg-gray-50 p-3">
+            <label
+              htmlFor="lmnLocalInstall"
+              className="flex cursor-pointer items-start gap-2 text-sm font-bold text-gray-800"
+            >
+              <input
+                id="lmnLocalInstall"
+                type="checkbox"
+                checked={localInstall}
+                onChange={(e) => setLocalInstall(e.target.checked)}
+                className="mt-0.5 cursor-pointer"
+              />
+              {t('token.localInstall')}
+            </label>
+            <p className="mt-1 pl-6 text-xs text-gray-500">{t('token.localInstallHint')}</p>
+          </div>
         )}
+
+        {adType !== 'new' &&
+          (target === 'linuxmuster' ? (
+            <p className="mt-2 text-sm text-gray-600">
+              {t('token.descriptionLinuxmuster')}
+            </p>
+          ) : (
+            <p className="mt-2 text-sm text-gray-600">
+              {t('token.descriptionGeneric')}
+            </p>
+          ))}
 
         <Button
           variant="btn-security"

--- a/apps/webinstaller/src/store/useInstallerStore.ts
+++ b/apps/webinstaller/src/store/useInstallerStore.ts
@@ -32,6 +32,9 @@ interface InstallerState {
   certificateConfigured: boolean;
   proxyDetected: boolean;
 
+  lmnLocalInstall: boolean;
+  lmnWebuiPort: number;
+
   lmnSshHost: string;
   lmnSshPort: number;
   lmnSshUser: string;
@@ -72,6 +75,7 @@ interface InstallerState {
   setInitialAdminGroup: (group: string) => void;
   setCertificateConfigured: (value: boolean) => void;
   setProxyDetected: (value: boolean) => void;
+  setLmnLocalInstall: (value: boolean) => void;
   setLmnSsh: (ssh: { host: string; port: number; user: string; password: string }) => void;
   setLmnBootstrapStatus: (status: LmnStatus) => void;
   setLmnPlaybookStatus: (status: LmnStatus) => void;
@@ -115,6 +119,8 @@ const initialState = {
   initialAdminGroup: '',
   certificateConfigured: false,
   proxyDetected: false,
+  lmnLocalInstall: false,
+  lmnWebuiPort: 8443,
   lmnSshHost: '',
   lmnSshPort: 22,
   lmnSshUser: 'root',
@@ -175,6 +181,8 @@ const useInstallerStore = create<InstallerState>()(
       setCertificateConfigured: (value) => set({ certificateConfigured: value }),
 
       setProxyDetected: (value) => set({ proxyDetected: value }),
+
+      setLmnLocalInstall: (value) => set({ lmnLocalInstall: value }),
 
       setLmnSsh: (ssh) =>
         set({

--- a/edulution-lmninstaller/playbooks/linuxmuster.yml
+++ b/edulution-lmninstaller/playbooks/linuxmuster.yml
@@ -543,6 +543,58 @@
       notify: Linuxmuster-WebUI neustarten
 
     # =========================================================================
+    # REBOOT-ERSATZ: gezielte Dienst-Neustarts statt vollem Neustart
+    # =========================================================================
+    # linuxmuster.net empfiehlt nach dem Setup einen Reboot. Wo das nicht moeglich
+    # ist, ersetzen wir ihn so weit wie sinnvoll:
+    #  - needrestart startet Dienste mit veralteten Bibliotheken neu (apt-Upgrade)
+    #  - der LMN-Stack wird gezielt neu gestartet, damit er die neue Konfiguration
+    #    liest -- bewusst OHNE Netzwerk (netplan/IP-Wechsel), um die laufende
+    #    Verbindung nicht zu kappen.
+    #  - Bleibt ein Kernel-Update, ist ein echter Reboot weiterhin noetig; das
+    #    wird am Ende gemeldet.
+
+    - name: needrestart installieren (falls nicht vorhanden)
+      ansible.builtin.apt:
+        name: needrestart
+        state: present
+      failed_when: false
+
+    - name: Dienste mit veralteten Bibliotheken automatisch neu starten
+      ansible.builtin.command:
+        cmd: needrestart -r a -b
+      register: needrestart_auto
+      changed_when: false
+      failed_when: false
+
+    - name: Installierte Dienste ermitteln
+      ansible.builtin.service_facts:
+
+    - name: LMN-Stack neu starten (Reboot-Ersatz, ohne Netzwerk)
+      ansible.builtin.systemd:
+        name: '{{ item }}'
+        state: restarted
+      loop:
+        - isc-dhcp-server
+        - ntpsec
+        - apparmor
+        - linuxmuster-api
+        - linuxmuster-webui
+      when: (item ~ '.service') in ansible_facts.services
+      failed_when: false
+
+    - name: Pruefen ob ein Kernel-Reboot noetig ist
+      ansible.builtin.command:
+        cmd: needrestart -k -b
+      register: needrestart_kernel
+      changed_when: false
+      failed_when: false
+
+    - name: Kernel-Reboot-Status merken
+      ansible.builtin.set_fact:
+        lmn_kernel_reboot_required: "{{ 'NEEDRESTART-KSTA: 3' in (needrestart_kernel.stdout | default('')) }}"
+
+    # =========================================================================
     # ABSCHLUSSMELDUNG
     # =========================================================================
 
@@ -561,7 +613,10 @@
 
           edulution Binduser: CN=edulutionui-binduser,OU=Management,OU=GLOBAL,{{ edulution_dc_parts }}
 
-          WICHTIG: System neustarten mit 'sudo reboot'
+          Dienste wurden gezielt neugestartet (Reboot-Ersatz, ohne Netzwerk).
+          {{ 'ACHTUNG: Der Kernel wurde aktualisiert - ein echter Reboot ist noetig!'
+             if (lmn_kernel_reboot_required | default(false) | bool)
+             else 'Kein Kernel-Reboot noetig - die Dienst-Neustarts genuegen.' }}
 
           ====================================================================
 

--- a/edulution-lmninstaller/playbooks/linuxmuster.yml
+++ b/edulution-lmninstaller/playbooks/linuxmuster.yml
@@ -42,6 +42,13 @@
     lmn_netmask: '255.255.0.0'
     lmn_gateway: '10.0.0.254'
 
+    # DNS-Forwarder fuer die Samba-interne DNS.
+    # linuxmuster-setup schreibt in die smb.conf zwingend
+    # "dns forwarder = <firewallip>". Ohne installierte Firewall zeigt das ins
+    # Leere und die externe Namensaufloesung (und damit apt) schlaegt fehl.
+    # Daher setzen wir nach dem Setup einen funktionierenden Resolver.
+    lmn_dns_forwarder: '9.9.9.9'
+
     # Server
     lmn_servername: 'server'
     lmn_domainname: 'linuxmuster.lan'
@@ -66,6 +73,13 @@
     lmn_skip_firewall: true
     lmn_unattended: true
     lmn_disable_auto_updates: true
+
+    # Lokale Installation (edulution-UI und LMN-Server auf derselben Maschine).
+    # Wird bei "gleiche Maschine" in der Installer-UI auf true gesetzt.
+    # In diesem Fall kollidiert die Ajenti-Web-UI (Port 443) mit dem Traefik
+    # von edulution, daher wird Ajenti auf lmn_webui_port verschoben.
+    lmn_local_install: false
+    lmn_webui_port: 8443
 
     # Firewall wird standardmaessig NICHT installiert (lmn_skip_firewall: true).
     # Die Firewall muss separat eingerichtet werden.
@@ -348,6 +362,17 @@
         mode: '0644'
       when: lmn_setup_result is defined and lmn_setup_result.rc == 0
 
+    # linuxmuster-setup verankert "dns forwarder = <firewallip>" in der
+    # smb.conf. Ohne Firewall ist das ein toter Resolver -> externe DNS-Namen
+    # (deb.linuxmuster.net, archive.ubuntu.com, ...) lassen sich nicht mehr
+    # aufloesen. Vor dem Samba-Neustart auf einen funktionierenden Forwarder
+    # umbiegen, damit die anschliessenden apt-Tasks nicht scheitern.
+    - name: DNS-Forwarder in smb.conf auf funktionierenden Resolver setzen
+      ansible.builtin.replace:
+        path: /etc/samba/smb.conf
+        regexp: '^(\s*dns forwarder\s*=\s*).*$'
+        replace: '\g<1>{{ lmn_dns_forwarder }}'
+
     - name: Samba AD DC neu starten
       ansible.builtin.systemd:
         name: samba-ad-dc
@@ -366,6 +391,16 @@
         echo "Samba LDAP nicht erreichbar nach 150 Sekunden"
         exit 1
       changed_when: false
+
+    - name: Warten bis externe DNS-Aufloesung funktioniert
+      ansible.builtin.command:
+        cmd: getent hosts deb.linuxmuster.net
+      register: lmn_dns_check
+      until: lmn_dns_check.rc == 0
+      retries: 12
+      delay: 5
+      changed_when: false
+      failed_when: lmn_dns_check.rc != 0
 
     # =========================================================================
     # EDULUTION BINDUSER ERSTELLEN (via sophomorix)
@@ -465,6 +500,42 @@
         daemon_reload: true
 
     # =========================================================================
+    # SSH-ZUGRIFF FUER EDULUTION-INSTALLER
+    # =========================================================================
+    # Erlaubt Root-/Passwort-Login ausschliesslich von localhost und aus dem
+    # Docker-Bridge-Netz (docker0, 172.17.0.0/16). Wird immer angelegt, wirkt
+    # sich aber nur auf Verbindungen aus diesen Netzen aus. Bei einer
+    # "gleiche Maschine"-Installation erreicht der edulution-Container den
+    # Host darueber ueber die docker0-IP.
+
+    - name: SSH-Konfiguration fuer edulution-installer erstellen
+      ansible.builtin.copy:
+        content: |
+          Match Address 127.0.0.1,172.17.0.0/16
+              PermitRootLogin yes
+              PasswordAuthentication yes
+        dest: /etc/ssh/sshd_config.d/edulution_installer.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: SSH-Dienst neustarten
+
+    # =========================================================================
+    # AJENTI-PORT ANPASSEN (nur bei lokaler Installation)
+    # =========================================================================
+    # Auf derselben Maschine belegt der edulution-Traefik den Host-Port 443.
+    # Damit die Ajenti-Web-UI (linuxmuster.net) nicht kollidiert, wird sie auf
+    # lmn_webui_port verschoben.
+
+    - name: Ajenti-Port anpassen (lokale Installation)
+      ansible.builtin.replace:
+        path: /etc/ajenti/config.yml
+        regexp: '(^\s*port:\s*)443\b'
+        replace: '\g<1>{{ lmn_webui_port }}'
+      when: lmn_local_install | bool
+      notify: Ajenti-Dienst neustarten
+
+    # =========================================================================
     # ABSCHLUSSMELDUNG
     # =========================================================================
 
@@ -478,7 +549,7 @@
           Server: {{ lmn_servername }}.{{ lmn_domainname }}
           IP:     {{ lmn_server_ip }}
 
-          Web-UI: https://{{ lmn_server_ip }}
+          Web-UI: https://{{ lmn_server_ip }}{{ (':' + lmn_webui_port | string) if (lmn_local_install | bool) else '' }}
           Login:  global-admin / {{ lmn_adminpw }}
 
           edulution Binduser: CN=edulutionui-binduser,OU=Management,OU=GLOBAL,{{ edulution_dc_parts }}
@@ -486,3 +557,18 @@
           WICHTIG: System neustarten mit 'sudo reboot'
 
           ====================================================================
+
+  # ===========================================================================
+  # HANDLERS
+  # ===========================================================================
+
+  handlers:
+    - name: SSH-Dienst neustarten
+      ansible.builtin.systemd:
+        name: ssh
+        state: restarted
+
+    - name: Ajenti-Dienst neustarten
+      ansible.builtin.systemd:
+        name: ajenti
+        state: restarted

--- a/edulution-lmninstaller/playbooks/linuxmuster.yml
+++ b/edulution-lmninstaller/playbooks/linuxmuster.yml
@@ -81,6 +81,19 @@
     lmn_local_install: false
     lmn_webui_port: 8443
 
+    # Datenplatte: linuxmuster legt seine Daten (/srv/samba, /srv/linbo) und /var
+    # auf einer zweiten Platte via LVM ab. Das erledigt lmn-appliance/lmn-prepare
+    # selbst, wenn man ihm die Platte per -l uebergibt (VG vg_srv, Volumes s.u.,
+    # Quota auf global/default-school). Ist eine zweite, LEERE Platte vorhanden,
+    # uebergeben wir sie automatisch.
+    lmn_setup_data_disk: true
+    # Leer lassen -> automatische Erkennung der ersten komplett leeren
+    # Nicht-System-Platte (z.B. /dev/vdb, /dev/sdb). Sonst Geraet explizit setzen.
+    lmn_data_disk: ''
+    # Leer lassen -> Standard von lmn-prepare:
+    # var:10,linbo:40,global:10,default-school:100%FREE
+    lmn_lvm_volumes: ''
+
     # Firewall wird standardmaessig NICHT installiert (lmn_skip_firewall: true).
     # Die Firewall muss separat eingerichtet werden.
 
@@ -88,7 +101,11 @@
     lmn_repo_url: 'https://deb.linuxmuster.net/'
     lmn_repo_gpg_url: 'https://deb.linuxmuster.net/pub.gpg'
     lmn_repo_distribution: 'lmn73'
-    lmn_appliance_url: 'https://raw.githubusercontent.com/linuxmuster/linuxmuster-prepare/master/lmn-appliance'
+    # lmn-appliance MUSS von einem 7.3-Release geladen werden: master hat die
+    # Auswertung von -l/--pvdevice verloren (die Datenplatte wuerde ignoriert)
+    # und wuerde ausserdem die lmn74-Quelle (7.4-Prerelease) einrichten.
+    lmn_prepare_version: 'v7.3.1'
+    lmn_appliance_url: 'https://raw.githubusercontent.com/linuxmuster/linuxmuster-prepare/{{ lmn_prepare_version }}/lmn-appliance'
 
     # Pakete
     lmn_additional_packages:
@@ -101,6 +118,7 @@
       - wget
       - curl
       - gnupg
+      - lvm2
 
   tasks:
     # =========================================================================
@@ -266,7 +284,42 @@
       ansible.builtin.set_fact:
         lmn_cidr: "{{ (lmn_server_ip + '/' + lmn_netmask) | ansible.utils.ipaddr('prefix') }}"
 
-    - name: lmn-appliance ausführen (Server-Profil, ohne LVM)
+    # -------------------------------------------------------------------------
+    # DATENPLATTE ERMITTELN (wird per -l an lmn-appliance uebergeben)
+    # -------------------------------------------------------------------------
+    - name: Leere zweite Platte fuer LVM ermitteln
+      ansible.builtin.shell: |
+        # Erste vollstaendig leere Nicht-System-Platte:
+        # keine Partitionen, kein Dateisystem, keine Signatur (fs/parttable/LVM).
+        for d in $(lsblk -dn -o NAME,TYPE | awk '$2=="disk"{print $1}'); do
+          dev="/dev/$d"
+          [ "$(lsblk -n -o NAME "$dev" | wc -l)" -eq 1 ] || continue
+          [ -z "$(lsblk -dn -o FSTYPE "$dev")" ] || continue
+          blkid "$dev" >/dev/null 2>&1 && continue
+          echo "$dev"; break
+        done
+      args:
+        executable: /bin/bash
+      register: lmn_detected_disk
+      changed_when: false
+      when: lmn_setup_data_disk | bool
+
+    - name: Zu verwendende Datenplatte festlegen
+      ansible.builtin.set_fact:
+        lmn_data_disk_final: "{{ (lmn_data_disk | default('', true)) or (lmn_detected_disk.stdout | default('') | trim) }}"
+      when: lmn_setup_data_disk | bool
+
+    - name: Hinweis wenn keine leere Datenplatte gefunden wurde
+      ansible.builtin.debug:
+        msg: >-
+          Keine leere zweite Platte gefunden - Installation erfolgt auf der
+          Systemplatte (kein separates LVM). Vorhandene Platten werden nie
+          ueberschrieben; ggf. lmn_data_disk explizit setzen.
+      when:
+        - lmn_setup_data_disk | bool
+        - (lmn_data_disk_final | default('')) == ''
+
+    - name: lmn-appliance ausführen (Server-Profil, LVM auf Datenplatte falls vorhanden)
       ansible.builtin.shell: |
         set -o pipefail
         /root/lmn-appliance -p server -u \
@@ -274,6 +327,8 @@
           -f {{ lmn_gateway }} \
           -d {{ lmn_domainname }} \
           -t {{ lmn_servername }} \
+          {{ ('-l ' + lmn_data_disk_final) if (lmn_data_disk_final | default('')) != '' else '' }} \
+          {{ ('-v ' + lmn_lvm_volumes) if (lmn_lvm_volumes | default('')) != '' else '' }} \
           2>&1 | while IFS= read -r line; do
           echo "$line"
         done

--- a/edulution-lmninstaller/playbooks/linuxmuster.yml
+++ b/edulution-lmninstaller/playbooks/linuxmuster.yml
@@ -417,6 +417,10 @@
       failed_when: false
       changed_when: false
 
+    # Nach dem samba-ad-dc-Neustart antwortet samba-tool (lokale DB) bereits,
+    # waehrend das Netzwerk-LDAP, das sophomorix nutzt, noch nicht bereit ist
+    # ("No connection to Samba4 AD!"). Daher den Aufruf mit kurzem Delay
+    # wiederholen, bis die Verbindung steht (nichts wird vorher angelegt).
     - name: edulutionui-binduser mit sophomorix erstellen
       ansible.builtin.command:
         cmd: >
@@ -425,6 +429,9 @@
           --random-passwd-save
       register: binduser_create_result
       when: binduser_exists.rc != 0
+      until: binduser_create_result.rc == 0
+      retries: 12
+      delay: 5
 
     - name: Debug - Binduser-Erstellung Ergebnis
       ansible.builtin.debug:

--- a/edulution-lmninstaller/playbooks/linuxmuster.yml
+++ b/edulution-lmninstaller/playbooks/linuxmuster.yml
@@ -533,7 +533,7 @@
         regexp: '(^\s*port:\s*)443\b'
         replace: '\g<1>{{ lmn_webui_port }}'
       when: lmn_local_install | bool
-      notify: Ajenti-Dienst neustarten
+      notify: Linuxmuster-WebUI neustarten
 
     # =========================================================================
     # ABSCHLUSSMELDUNG
@@ -568,7 +568,7 @@
         name: ssh
         state: restarted
 
-    - name: Ajenti-Dienst neustarten
+    - name: Linuxmuster-WebUI neustarten
       ansible.builtin.systemd:
-        name: ajenti
+        name: linuxmuster-webui
         state: restarted


### PR DESCRIPTION
## Overview

Adds a "same machine" option to install the linuxmuster.net server on the same host as the edulution container, plus several robustness fixes to the linuxmuster install playbook found while testing.

## Same-machine install
- New **"Auf dieser Maschine installieren"** toggle in the setup wizard.
- The installer reaches the host over SSH via the **docker0 gateway IP** (auto-detected, new `GET /api/docker-host-ip`); the SSH-host field is prefilled and locked.
- The host **install script** creates `/etc/ssh/sshd_config.d/edulution_installer.conf` (root/password login from `127.0.0.1` + `172.17.0.0/16`) and restarts SSH **before** the container starts — needed because the container SSHes into the host before the playbook runs.
- The playbook moves the **Ajenti web UI off 443** (to `lmn_webui_port`, default `8443`) so it doesn't collide with the edulution Traefik; edulution's **webdav access follows to the new port** (check, Traefik route, `EDUI_WEBDAV_URL`).
- On same-machine, **server IP / netmask / gateway are hidden** and auto-detected (already correct on an existing host); remote installs keep the editable fields.

## Install playbook fixes
- **Samba DNS forwarder:** `linuxmuster-setup` hardcodes `dns forwarder = <firewallip>` in `smb.conf`; without a firewall that resolver is dead and post-setup `apt` fails. Now rewritten to a working resolver (`lmn_dns_forwarder`, default `9.9.9.9`) before the Samba restart, with a DNS-resolution gate before the apt tasks.
- **sophomorix binduser:** retry `--create-global-binduser` until Samba's network LDAP is reachable (after the restart `samba-tool` answers while sophomorix's LDAP connection isn't ready yet).
- **Service restart:** restart `linuxmuster-webui` instead of the non-existent `ajenti` service.
- **Reboot replacement:** run `needrestart` (lib/kernel) + targeted restarts of the LMN stack (dhcp/ntpsec/apparmor/api/webui) without touching networking, and report whether a real kernel reboot is still required.
- **Data disk (LVM):** auto-detect the first completely empty non-system disk and pass it to `lmn-appliance` via `-l`, so it creates the standard LVM layout (VG `vg_srv`: `/var`, `/srv/linbo`, `/srv/samba/global`, `/srv/samba/schools/default-school` with quota). `lmn-appliance` is pinned to **v7.3.1** because `master` dropped the `-l` handling and would set up the lmn74 (7.4 prerelease) repo. Disks with existing data are never touched.

## Notes
- The `--branch <name>` installer option and per-branch CI image build (needed to test this branch) are already on `main`.
- The same-machine sshd drop-in is currently created unconditionally in the install script; it can be gated behind a flag before/when merging if preferred.
