### PR TITLE
Document EDUI_FILEPROXY_API_URL for new installs

### DIFF
--- a/apps/public-page/public/download/docker-compose.yml.template
+++ b/apps/public-page/public/download/docker-compose.yml.template
@@ -30,6 +30,11 @@ services:
       #EDUI_MAIL_IMAP_TIMEOUT:
       # Cache TTL for storing oidc config request in redis in ms, default 1h
       #EDUI_OIDC_CONFIG_CACHE_TTL=
+      # optional: fallback address of the fileproxy serving the wiki HTTP API,
+      # used when a WebDAV root server carries no address of its own. Must be an
+      # origin without a path and must be the fileproxy itself, not the public
+      # UI host, e.g. https://fileproxy.example.edu:8443
+      #EDUI_FILEPROXY_API_URL=
       KEYCLOAK_API: http://edu-keycloak:8080/auth
       KEYCLOAK_EDU_UI_REALM: edulution
       KEYCLOAK_EDU_UI_CLIENT_ID: edu-ui


### PR DESCRIPTION
## Problem

edu-api can now address each fileproxy directly instead of deriving the address from the WebDAV share URL. That indirection is what made a Traefik route for `/wiki` necessary on the public host — and that route shadows the SPA's own wiki deep links, so reloading a wiki page returns 404.

## Approach

Five comment lines: `EDUI_FILEPROXY_API_URL` joins the commented optional-var block in the compose template, so operators can discover it.

The generated `edulution.env` deliberately does **not** gain the variable. The installer collects no fileproxy address anywhere — not in the install form, the request model, or the store — so the only value it could emit is `https://<lmnExternalDomain>`, which is exactly what the fallback in edu-api already derives. Adding it would cost a config line, a Pydantic field, a `Data` field, a form input, a store field and two translation keys in exchange for no behavioural difference. Sites needing a different address set it by hand, or per WebDAV root server in the admin settings.

Nothing has to be removed here: `main` has never provisioned a `/wiki` route. The `/wiki` router lives only on the unmerged `feat/edulution-fileproxy-playbook` branch, where it should be dropped before that branch merges — see the comment on #41.

`webdav.yml` is untouched. It serves the browser, not edu-api, so this change does not affect it.

## Testing

Comment-only change to a template. Verified the template still parses as YAML and that all seven services survive.

Refs edulution-io/edulution-ui#3141
