### PR TITLE
Run MongoDB as a single-node replica set

### DIFF
--- a/apps/public-page/public/download/docker-compose.yml.template
+++ b/apps/public-page/public/download/docker-compose.yml.template
@@ -61,14 +61,55 @@ services:
     restart: always
     env_file:
       - edulution.env
+    # MongoDB runs as a single-node replica set (rs0) because the API writes
+    # across collections in multi-document transactions, which are only
+    # available on a replica set. Enabling replication together with
+    # authorization requires a keyfile for internal auth; it is generated once
+    # on first start and kept in ./data/db-keyfile.
+    entrypoint:
+      - bash
+      - -c
+      - |
+        set -e
+        KEYFILE=/keyfile/mongo.key
+        if [ ! -s "$$KEYFILE" ]; then
+          openssl rand -base64 756 > "$$KEYFILE"
+        fi
+        chmod 400 "$$KEYFILE"
+        chown mongodb:mongodb "$$KEYFILE" 2>/dev/null || true
+        exec docker-entrypoint.sh "$$@"
+      - bash
+    command:
+      - mongod
+      - --replSet
+      - rs0
+      - --keyFile
+      - /keyfile/mongo.key
+      - --bind_ip_all
     volumes:
       - ./data/db:/data/db
+      - ./data/db-keyfile:/keyfile
+    ulimits:
+      nofile:
+        soft: 64000
+        hard: 64000
+    # Initiates the replica set on the first run and reports healthy only once
+    # a PRIMARY exists, so that edu-api starts against a transaction capable
+    # database. rs.initiate() is idempotent, an existing standalone data
+    # directory is promoted in place.
     healthcheck:
-      test: [ "CMD", "mongosh", "--eval", "db.adminCommand('ping')" ]
+      test:
+        - CMD-SHELL
+        - >
+          tr -d '[:space:]' < /keyfile/mongo.key |
+          mongosh --quiet -u __system
+          --authenticationDatabase local --eval "
+          let status; try { status = rs.status(); } catch (e) { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: 'edulution-db:27017' }] }); status = rs.status(); }
+          const primary = status && status.members && status.members.some(m => m.stateStr === 'PRIMARY'); if (!primary) { quit(1); }"
       interval: 5s
-      timeout: 1s
+      timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 15s
 
   edu-redis:
     container_name: edulution-redis

--- a/apps/webinstaller-api/app/main.py
+++ b/apps/webinstaller-api/app/main.py
@@ -816,7 +816,11 @@ EDUI_WEBDAV_URL=https://{webdav_netloc}/webdav/
 
 MONGODB_USERNAME=root
 MONGODB_PASSWORD={mongodb_secret}
-MONGODB_SERVER_URL=mongodb://root:{mongodb_secret}@edu-db:27017/
+MONGODB_AUTH_SOURCE=admin
+# directConnection=true skips replica set discovery, the single node set only
+# advertises its container name. Quoted because this file is also sourced by
+# the shell installer, where the unquoted "&" would split the assignment.
+MONGODB_SERVER_URL="mongodb://root:{mongodb_secret}@edu-db:27017/?replicaSet=rs0&directConnection=true"
 
 KEYCLOAK_EDU_UI_SECRET={keycloak_eduui_secret}
 KEYCLOAK_EDU_API_CLIENT_SECRET={keycloak_eduapi_secret}


### PR DESCRIPTION
Implements the deployment side of edulution-io/edulution-ui#3161 for fresh installations: the bundled MongoDB now runs as the single-node replica set `rs0`, so the API can use multi-document transactions (edulution-io/edulution-ui#2960) instead of latching onto the non-transactional fallback at boot.

## Changes

**`docker-compose.yml.template` — `edu-db`**

* entrypoint wrapper generates `/keyfile/mongo.key` (`openssl rand -base64 756`, `chmod 400`, `chown mongodb`) on first start and then execs `docker-entrypoint.sh`
* `command: mongod --replSet rs0 --keyFile /keyfile/mongo.key --bind_ip_all`
* additional bind mount `./data/db-keyfile:/keyfile`
* `ulimits.nofile` 64000/64000
* health check authenticates as `__system` with the keyfile, calls `rs.initiate()` if the set does not exist yet and only reports healthy once a `PRIMARY` is available

The replica set member host is `edulution-db:27017`, matching the container name of this stack. `edu-api` already depends on `edu-db` with `condition: service_healthy`, so the rollout order (DB primary before API start) is enforced by compose.

Deviation from the reference definition in the UI repo: the keyfile lives in a bind mount under `./data` rather than in a named volume, because this stack keeps all instance state in the installation directory (`/srv/docker/edulution-ui/data`) and a named volume would be missed by directory-level backups.

**`main.py` — generated `edulution.env`**

```
MONGODB_AUTH_SOURCE=admin
MONGODB_SERVER_URL="mongodb://root:<secret>@edu-db:27017/?replicaSet=rs0&directConnection=true"
```

`directConnection=true` skips replica set discovery — the single member advertises `edulution-db`, while the API addresses it as `edu-db`. The value is quoted because `edulution.env` is also `source`d by the installer script, where an unquoted `&` would split the assignment; compose strips the quotes when reading `env_file`.

## Verification

Ran against the real template (mongo:7, docker compose):

* fresh start — container reports healthy after ~6s, `rs.status()` reports `rs0` / `PRIMARY` / `edulution-db:27017`, a multi-document transaction commits
* restart — stays healthy, keyfile (`-r--------`, uid 999) and data are reused, no re-initiation
* migration — started a standalone `edu-db` with the previous service definition, inserted a document, switched to the new definition against the same `./data/db`: converts in place, existing data and the root user are preserved, transactions work afterwards
* client view — `mongosh "mongodb://root:…@edu-db:27017/?replicaSet=rs0&directConnection=true&authSource=admin"` from a separate container connects and sees `rs0`

## Out of scope

Existing installations are not touched here — the installer script aborts when `edulution.env` already exists. Migrating deployed instances (env file extension, root user check before the keyfile is enabled, ordered restart) belongs to the edulution-manager, as described in edulution-io/edulution-ui#3161.