### PR TITLE
Point MAILCOW_API_URL at the internal container hostname

### DIFF
--- a/apps/webinstaller-api/app/main.py
+++ b/apps/webinstaller-api/app/main.py
@@ -854,7 +854,7 @@ POSTGRES_PASSWORD={postgres_secret}
 
 KEYCLOAK_EDU_MAILCOW_SYNC_SECRET={keycloak_edumailcow_sync_secret}
 MAILCOW_API_TOKEN={mailcow_api_secret}
-MAILCOW_API_URL=https://edu-traefik/sogo-mail
+MAILCOW_API_URL=https://mailcowdockerized-nginx-mailcow-1
 
 # edulution-guacamole
 


### PR DESCRIPTION
Writes `MAILCOW_API_URL=https://mailcowdockerized-nginx-mailcow-1` into the generated `.env` instead of `https://edu-traefik/sogo-mail`.

edulution-api has been in the mailcow Docker network since edulution-mail v1.1.13 (`build/entrypoint.sh` runs `docker network connect` for the `edulution-api` container on every start), so it can reach the mailcow nginx directly. The docs already document the internal hostname as the value to configure by hand; only the webinstaller default was still pointing through Traefik.

Beyond removing the detour, this is the prerequisite for narrowing the `/sogo-mail` Traefik route from `PathPrefix` to `Path('/sogo-mail/sogo-auth.php')` — with the old default in place, that narrowing would break mailcow API access on every fresh installation.

Runtime configuration takes precedence over the environment variable in edulution-api, so this only affects installations where the setting was never configured by hand. Existing installations are covered by the migration note in edulution-io/edulution-docs#122.

Grepped the installer for other `/sogo-mail` references; this was the only one.

Related:
- edulution-io/edulution-mail#61
- edulution-io/edulution-docs#122

Closes #48