### PR TITLE
fix(installer): require AVX so MongoDB does not crash mid-install

### DIFF
--- a/apps/public-page/public/installer
+++ b/apps/public-page/public/installer
@@ -92,6 +92,17 @@ if ! (echo "$cpu_flags" | grep -qwE 'cx16' && \
     exit 1
 fi
 
+# MongoDB ab 5.0 (hier: mongo:7) wird mit AVX kompiliert und stuerzt ohne diese
+# CPU-Erweiterung sofort mit "Illegal instruction (core dumped)" ab. AVX gehoert
+# zu x86-64-v3 und ist von der Pruefung oben daher NICHT abgedeckt: verbreitete
+# Standard-CPU-Typen wie "x86-64-v2-AES" (Default in Proxmox VE 8) bestehen den
+# v2-Test, lassen die Installation aber spaeter an edulution-db scheitern.
+if ! echo "$cpu_flags" | grep -qwE 'avx'; then
+    echo "[!] Die CPU unterstützt kein AVX (x86-64-v3), das von der Datenbank (MongoDB) benötigt wird."
+    echo "[!] Bitte stelle den CPU-Typ deiner VM auf 'host' (mindestens 'x86-64-v3') um!"
+    exit 1
+fi
+
 if [ -f "${DIRECTORY}edulution.env" ]; then
   echo "[!] Die edulution UI scheint bereits installiert zu sein. Bitte prüfe das Verzeichnis '$DIRECTORY'!"
   exit 1


### PR DESCRIPTION
Fixes the root cause behind edulution-io/edulution-public#13.

## Problem

The installer's CPU preflight check validates **x86-64-v2**:

```bash
cx16, lahf_lm, popcnt, sse4_1, sse4_2, ssse3
```

But the compose template pins `mongo:7`, and MongoDB 5.0+ is compiled with **AVX** as a hard requirement. AVX belongs to **x86-64-v3**, so it is not covered by the check above.

The gap is not exotic, it is the default: a Proxmox VE 8 VM ships with CPU type `x86-64-v2-AES`, which passes the v2 check and has no AVX. Those installs run all the way through Docker setup, the web installer, Keycloak configuration and a 50-image pull — roughly 20 minutes — and only then fail:

```
edulution-db | /usr/local/bin/docker-entrypoint.sh: line 416: 29 Illegal instruction (core dumped) "${mongodHackedArgs[@]}" --fork
```

Line 416 is the temporary `mongod --fork` that the official image uses to create the root user, so the database never initialises and every later `docker compose up` repeats the crash.

The failure also mis-reports itself. Compose aborts the entire `up` as soon as one dependency fails, marking everything still pending as `Error` — including `edulution-redis`, which was merely inside its 10s `start_period` and had already logged `Ready to accept connections tcp`. That is why the issue was filed against Redis.

## Change

Add an `avx` check after the existing v2 check, with a message that names both the cause (MongoDB) and the fix (VM CPU type). Kept as a separate `if` so the two failure modes stay distinguishable.

## Verification

- `bash -n` passes.
- `grep -qwE 'avx'` accepts `... sse4_2 avx avx2` and `... avx512f avx`; rejects the Proxmox default flag set `cx16 lahf_lm popcnt sse4_2 aes`. The `-w` word boundary also keeps `avx_vnni` alone from matching.

## Note for affected users

Fixing the CPU type is not sufficient on an already-broken host — the Mongo data directory never initialised and must be discarded:

```bash
docker compose down
rm -rf /srv/docker/edulution-ui/data/db/*
docker compose up -d
```
